### PR TITLE
Extend DM permissions

### DIFF
--- a/starlight_help/src/content/docs/miatsuco-custom-features.mdx
+++ b/starlight_help/src/content/docs/miatsuco-custom-features.mdx
@@ -71,3 +71,34 @@ people in the conversation see.
     </FlattenedSteps>
   </TabItem>
 </Tabs>
+
+## Configure who can send direct messages without an authorizer present
+
+<AdminOnly />
+
+By default, Zulip lets you require that certain users (for example,
+moderators or admins) be included in every direct message conversation, by
+setting **Who can authorize a direct message conversation**. This fork adds a
+companion setting, **Who can direct message others in this setting without an
+authorizer present**, which lets you name a group whose members may exchange
+direct messages among themselves without one of those authorizing users
+present.
+
+This is useful when you want direct messages to generally require an
+authorizer, but still allow a trusted group (for instance, everyone in a
+given team) to message each other freely.
+
+<ZulipNote>
+  An individual can choose to be stricter than this allowance for their own
+  direct messages; see [Restrict who can direct message
+  you](#restrict-who-can-direct-message-you).
+</ZulipNote>
+
+<FlattenedSteps>
+  <NavigationSteps target="settings/organization-permissions" />
+
+  1. Under **Direct message permissions**, set **Who can direct message
+     others in this setting without an authorizer present**.
+
+  <SaveChanges />
+</FlattenedSteps>

--- a/starlight_help/src/content/docs/miatsuco-custom-features.mdx
+++ b/starlight_help/src/content/docs/miatsuco-custom-features.mdx
@@ -102,3 +102,34 @@ given team) to message each other freely.
 
   <SaveChanges />
 </FlattenedSteps>
+
+## Restrict who can direct message you
+
+You can choose to only take part in direct message conversations where every
+other participant is able to authorize direct messages (a member of your
+organization's **Who can authorize a direct message conversation** group,
+such as moderators or admins). When this is enabled, a direct message that
+includes anyone who cannot authorize it will not be delivered, even if an
+authorizing user is also included.
+
+This is a personal setting, and it is stricter than any organization-level
+allowance: it applies even to users who could otherwise message you without
+an authorizer present. It also applies to direct messages you send, since a
+direct message is a two-way conversation.
+
+<ZulipNote>
+  Because this depends on your organization's **Who can authorize a direct
+  message conversation** group, the setting shows who can currently authorize
+  your direct messages once you enable it.
+</ZulipNote>
+
+<Tabs>
+  <TabItem label="Desktop/Web">
+    <FlattenedSteps>
+      <NavigationSteps target="settings/account-and-privacy" />
+
+      1. Under **Privacy**, toggle **Restrict direct messages to only those
+         who can authorize them**.
+    </FlattenedSteps>
+  </TabItem>
+</Tabs>

--- a/web/src/blueslip_stacktrace.ts
+++ b/web/src/blueslip_stacktrace.ts
@@ -128,25 +128,36 @@ export async function display_stacktrace(ex: unknown, message?: string): Promise
             });
             break;
         }
-        const stackframes: CleanStackFrame[] =
-            ex instanceof Error
-                ? await Promise.all(
-                      ErrorStackParser.parse(ex).map(async (location: StackFrame) => {
-                          try {
-                              location = await stack_trace_gps.getMappedLocation(location);
-                          } catch {
-                              // Use unmapped location
-                          }
-                          return {
-                              full_path: location.getFileName(),
-                              show_path: clean_path(location.getFileName()),
-                              line_number: location.getLineNumber(),
-                              function_name: clean_function_name(location.getFunctionName()),
-                              context: await get_context(location),
-                          };
-                      }),
-                  )
-                : [];
+        let parsed_stackframes: StackFrame[] = [];
+        if (ex instanceof Error) {
+            try {
+                parsed_stackframes = ErrorStackParser.parse(ex);
+            } catch {
+                // Some Error instances have no parseable stack (for example, a
+                // DOMException from a failed or interrupted
+                // HTMLMediaElement.play()), and ErrorStackParser throws on
+                // those. Degrade to an empty stacktrace rather than letting
+                // that throw escape the unhandledrejection handler and surface
+                // as a second, misleading "Cannot parse given Error object".
+                parsed_stackframes = [];
+            }
+        }
+        const stackframes: CleanStackFrame[] = await Promise.all(
+            parsed_stackframes.map(async (location: StackFrame) => {
+                try {
+                    location = await stack_trace_gps.getMappedLocation(location);
+                } catch {
+                    // Use unmapped location
+                }
+                return {
+                    full_path: location.getFileName(),
+                    show_path: clean_path(location.getFileName()),
+                    line_number: location.getLineNumber(),
+                    function_name: clean_function_name(location.getFunctionName()),
+                    context: await get_context(location),
+                };
+            }),
+        );
         let more_info: string | undefined;
         if (ex instanceof BlueslipError) {
             more_info = JSON.stringify(ex.more_info, null, 4);

--- a/web/src/compose.ts
+++ b/web/src/compose.ts
@@ -289,6 +289,16 @@ export let send_message = (): void => {
         assert(message !== undefined);
         echo.message_send_error(message.id, response);
 
+        // Also surface the failure reason as a compose banner. This matches
+        // the non-echoed path above, avoids being missed when message is
+        // scrolled out of view, and works on touch devices (where the
+        // message-row tooltip is not reachable).
+        compose_banner.show_error_message(
+            response,
+            compose_banner.CLASSNAMES.generic_compose_error,
+            $("#compose_banners"),
+        );
+
         // We might not have updated the draft count because we assumed the
         // message would send. Ensure that the displayed count is correct.
         drafts.sync_count();

--- a/web/src/echo.ts
+++ b/web/src/echo.ts
@@ -13,6 +13,7 @@ import * as compose_notifications from "./compose_notifications.ts";
 import * as compose_ui from "./compose_ui.ts";
 import * as echo_state from "./echo_state.ts";
 import * as hash_util from "./hash_util.ts";
+import {$t} from "./i18n.ts";
 import * as local_message from "./local_message.ts";
 import * as markdown from "./markdown.ts";
 import type {InsertNewMessagesOpts} from "./message_events.ts";
@@ -127,14 +128,17 @@ function hide_retry_spinner($row: JQuery): boolean {
     return true;
 }
 
-function show_message_failed(message_id: number, _failed_msg: string): void {
+function show_message_failed(message_id: number, failed_msg: string): void {
     // Failed to send message, so display inline retry/cancel
     message_live_update.update_message_in_all_views(message_id, ($row) => {
         $row.find(".slow-send-spinner").addClass("hidden");
         const $message_controls = $row.find(".message_controls");
-        $message_controls.html(render_message_controls_failed_msg());
+        // Surface the specific error so the sender can see why the message
+        // didn't go through. Fall back to the plain "Retry" label when the
+        // failure has no specific reason (e.g., a network timeout).
+        const retry_tooltip = failed_msg === "" ? $t({defaultMessage: "Retry"}) : failed_msg;
+        $message_controls.html(render_message_controls_failed_msg({retry_tooltip}));
     });
-    // TODO: Show the `_failed_msg` in the UI, describing the reason for the failure.
 }
 
 function show_failed_message_success(message_id: number): void {

--- a/web/src/group_permission_settings.ts
+++ b/web/src/group_permission_settings.ts
@@ -65,6 +65,7 @@ const realm_group_setting_names_supporting_anonymous_groups = [
     "create_multiuse_invite_group",
     "direct_message_initiator_group",
     "direct_message_permission_group",
+    "direct_message_self_authorize_group",
     "workplace_users_group",
 ] as const;
 

--- a/web/src/message_util.ts
+++ b/web/src/message_util.ts
@@ -165,6 +165,27 @@ export function make_check_message_permission_for_dm_candidate(
         realm.realm_direct_message_permission_group,
     );
 
+    // Fork feature (miatsuco): the self-authorize path. A DM is authorized
+    // without a permission-group member if every participant is in the
+    // self-authorize group. So the current user being in it, plus every
+    // current human recipient being in it, means a candidate who is also in
+    // it keeps the DM authorized.
+    const self_authorize_group_user_ids = user_groups.get_user_ids_in_setting_group(
+        realm.realm_direct_message_self_authorize_group,
+    );
+    const is_current_user_in_self_authorize_group = user_groups.is_user_in_setting_group(
+        realm.realm_direct_message_self_authorize_group,
+        current_user_id,
+    );
+    const all_human_recipients_can_self_authorize = recipient_ids.every(
+        (user_id) =>
+            people.is_valid_bot_user(user_id) ||
+            user_id === current_user_id ||
+            self_authorize_group_user_ids.has(user_id),
+    );
+    const self_authorize_path_available =
+        is_current_user_in_self_authorize_group && all_human_recipients_can_self_authorize;
+
     return (candidate_user_id: number): boolean => {
         // Include bots when all recipients are bots.
         if (all_recipients_are_bots && people.is_valid_bot_user(candidate_user_id)) {
@@ -172,6 +193,20 @@ export function make_check_message_permission_for_dm_candidate(
         }
 
         const is_candidate_in_permission_group = permission_group_user_ids.has(candidate_user_id);
+
+        // Fork feature (miatsuco): if the self-authorize path is available
+        // and the candidate is also in the group (or a bot), the DM stays
+        // authorized without a permission-group member. The current user
+        // being able to start is implied here, because the self-authorize
+        // group is expected to be a subset of the initiator group; if it is
+        // not, the server still enforces the start rule.
+        if (
+            self_authorize_path_available &&
+            (people.is_valid_bot_user(candidate_user_id) ||
+                self_authorize_group_user_ids.has(candidate_user_id))
+        ) {
+            return true;
+        }
 
         // Current user can initiate and the candidate is in the permission group.
         if (is_current_user_in_initiator_group && is_candidate_in_permission_group) {

--- a/web/src/miatsuco_dm_authorizer_display.ts
+++ b/web/src/miatsuco_dm_authorizer_display.ts
@@ -1,0 +1,147 @@
+import $ from "jquery";
+
+import render_input_pill from "../templates/input_pill.hbs";
+
+import {$t} from "./i18n.ts";
+import * as people from "./people.ts";
+import {realm} from "./state_data.ts";
+import type {GroupSettingValue} from "./state_data.ts";
+import * as user_group_popover from "./user_group_popover.ts";
+import * as user_groups from "./user_groups.ts";
+
+// MiAtSu.Co fork: the "restrict direct messages to only those who can authorize
+// them" personal setting (miatsuco_restrict_dms_to_authorizers) is hard to act
+// on without knowing who those authorizers currently are. When the setting is
+// enabled, this module shows the current members of the realm's
+// direct_message_permission_group as read-only pills beneath the checkbox. The
+// pills are shown/hidden purely by the checkbox state (see settings.css), so
+// there is no separate expander control here.
+//
+// The pills are deliberately view-only, distinct from the editable
+// group-setting pickers in admin settings:
+//   - Group and role values render as group pills carrying data-user-group-id,
+//     which open the shared user-group popover in its view_only mode (see
+//     user_group_popover.ts): the popover lists members but hides navigation
+//     into group administration. Its member list is already access-filtered, so
+//     a guest only ever sees members they are otherwise allowed to see.
+//   - Individually-listed users render as non-interactive pills (no profile
+//     card, no click target), since this surface is purely informational.
+
+function render_group_pill(group_id: number): string | undefined {
+    const group = user_groups.maybe_get_user_group_from_id(group_id);
+    if (group === undefined) {
+        return undefined;
+    }
+    const member_count = user_groups.get_recursive_group_members(group).size;
+    return render_input_pill({
+        display_value: user_groups.get_display_group_name(group.name),
+        group_id,
+        show_group_members_count: true,
+        group_members_count: member_count,
+        // Read-only display: suppress the removable-pill [x] close button.
+        disabled: true,
+    });
+}
+
+function render_user_pill(user_id: number): string | undefined {
+    const user = people.maybe_get_user_by_id(user_id, true);
+    if (user === undefined) {
+        return undefined;
+    }
+    // A plain, non-interactive pill: no data-user-id and no profile-card
+    // class, so it renders the name without any click behavior. disabled
+    // suppresses the removable-pill [x] close button.
+    return render_input_pill({
+        display_value: people.get_full_name(user_id),
+        disabled: true,
+    });
+}
+
+// Exported for testing.
+export function build_pills_html(setting_value: GroupSettingValue): string {
+    const group_ids: number[] =
+        typeof setting_value === "number" ? [setting_value] : [...setting_value.direct_subgroups];
+    const member_ids: number[] =
+        typeof setting_value === "number" ? [] : [...setting_value.direct_members];
+
+    const pieces: string[] = [];
+    for (const group_id of group_ids) {
+        const html = render_group_pill(group_id);
+        if (html !== undefined) {
+            pieces.push(html);
+        }
+    }
+    for (const user_id of member_ids) {
+        const html = render_user_pill(user_id);
+        if (html !== undefined) {
+            pieces.push(html);
+        }
+    }
+    return pieces.join("");
+}
+
+export function render_pills($container: JQuery): void {
+    const $pills = $container.find(".miatsuco-dm-authorizers-pills");
+    if ($pills.length === 0) {
+        return;
+    }
+    const html = build_pills_html(realm.realm_direct_message_permission_group);
+    if (html === "") {
+        $pills.empty();
+        $pills.append(
+            $("<span>")
+                .addClass("miatsuco-dm-authorizers-empty")
+                .text(
+                    $t({
+                        defaultMessage: "No one can currently authorize direct messages.",
+                    }),
+                ),
+        );
+        return;
+    }
+    $pills.html(html);
+}
+
+export function set_up($container: JQuery): void {
+    const $disclosure = $container.find(".miatsuco-dm-authorizers");
+    if ($disclosure.length === 0) {
+        return;
+    }
+
+    // The settings_checkbox partial renders an empty container for this
+    // setting's content. Mount a short hint and the read-only pill container
+    // inside it, so they belong to the setting's own block (and do not pick up
+    // the vertical spacing between separate settings). Visibility is driven
+    // entirely by the checkbox state in CSS.
+    $disclosure.empty();
+    $disclosure.append(
+        $("<div>")
+            .addClass("miatsuco-dm-authorizers-hint")
+            .text($t({defaultMessage: "People who can authorize direct messages:"})),
+    );
+    $disclosure.append($("<div>").addClass("miatsuco-dm-authorizers-pills pill-container"));
+
+    render_pills($container);
+
+    // Open the shared user-group popover in view_only mode when a group or
+    // role pill is clicked. Individual-user pills carry no data-user-group-id
+    // and are ignored here.
+    $disclosure.on(
+        "click",
+        ".miatsuco-dm-authorizers-pills .pill[data-user-group-id]",
+        function (this: HTMLElement, e) {
+            e.stopPropagation();
+            user_group_popover.toggle_user_group_info_popover(this, undefined, true);
+        },
+    );
+}
+
+// Called from the realm-settings dispatch path when
+// direct_message_permission_group changes, so the displayed pills stay current.
+export function rerender_if_present(): void {
+    const $container = $("#settings_content");
+    if ($container.length === 0) {
+        return;
+    }
+    render_pills($container);
+}

--- a/web/src/miatsuco_inline_video.ts
+++ b/web/src/miatsuco_inline_video.ts
@@ -30,6 +30,29 @@ import $ from "jquery";
 // markdown output or editing its lightbox handler. See
 // docs/contributing/miatsuco-fork-conventions.md.
 
+// Map a video URL to the container MIME type the backend uses to decide the
+// file is an inline video (see is_video in zerver/lib/markdown/__init__.py:
+// video/mp4, video/quicktime, video/webm). The <video> carries only a src, no
+// type attribute, so the extension is all we have. This is a coarse container
+// check, not a codec check; it is used only to detect a browser that cannot
+// play the container at all, so returning undefined (proceed as normal) for
+// anything unrecognized is the safe default.
+function container_mime_type_for_url(src: string): string | undefined {
+    // Drop any query string or fragment before reading the extension.
+    const path = src.split(/[?#]/, 1)[0] ?? src;
+    const extension = path.split(".").pop()?.toLowerCase();
+    switch (extension) {
+        case "mp4":
+            return "video/mp4";
+        case "mov":
+            return "video/quicktime";
+        case "webm":
+            return "video/webm";
+        default:
+            return undefined;
+    }
+}
+
 export function enhance_inline_videos(content: JQuery): void {
     // Callers pass a container element whose inline videos are descendants
     // (the rendered-content hook passes the message content wrapper; the
@@ -47,6 +70,31 @@ export function enhance_inline_videos(content: JQuery): void {
         if ($video.length === 0) {
             return;
         }
+
+        // If the browser is certain it cannot play this container, present the
+        // download-link fallback instead of a player that would refuse to
+        // start. A refused native play() surfaces as a promise rejection, not
+        // an "error" event, so upstream's error handler never fires for it and
+        // the player would otherwise sit there snapping back to paused. We act
+        // only on canPlayType's definitive "" (cannot play); "maybe" and
+        // "probably" both proceed, so a file the browser might play is never
+        // hidden. This is a container check, not a codec check, so it does not
+        // catch a supported container holding an unsupported codec; that case
+        // still relies on the error-event fallback.
+        const video_element = $video[0];
+        const src = $video.attr("src");
+        if (
+            video_element !== undefined &&
+            typeof video_element.canPlayType === "function" &&
+            src !== undefined
+        ) {
+            const mime_type = container_mime_type_for_url(src);
+            if (mime_type !== undefined && video_element.canPlayType(mime_type) === "") {
+                $container.addClass("video-format-unsupported");
+                return;
+            }
+        }
+
         $container.attr("data-miatsuco-inline-video", "1");
 
         // Turn the poster preview into a real player.

--- a/web/src/people.ts
+++ b/web/src/people.ts
@@ -738,6 +738,31 @@ export function user_can_direct_message(recipient_ids_string: string): boolean {
         return true;
     }
 
+    // Fork feature (miatsuco): a DM is authorized without a
+    // permission-group member if every participant (me and all human,
+    // non-self recipients) is in the self-authorize group. Mirrors the backend
+    // in check_can_send_direct_message.
+    if (is_user_in_setting_group(realm.realm_direct_message_self_authorize_group, my_user_id)) {
+        let all_other_human_recipients_can_self_authorize = true;
+        for (const recipient_id of recipient_ids) {
+            if (is_valid_bot_user(recipient_id) || recipient_id === my_user_id) {
+                continue;
+            }
+            if (
+                !is_user_in_setting_group(
+                    realm.realm_direct_message_self_authorize_group,
+                    recipient_id,
+                )
+            ) {
+                all_other_human_recipients_can_self_authorize = false;
+                break;
+            }
+        }
+        if (all_other_human_recipients_can_self_authorize) {
+            return true;
+        }
+    }
+
     let other_human_recipients_exist = false;
     for (const recipient_id of recipient_ids) {
         if (is_valid_bot_user(recipient_id) || recipient_id === my_user_id) {

--- a/web/src/rendered_markdown.ts
+++ b/web/src/rendered_markdown.ts
@@ -408,6 +408,17 @@ export const update_elements = ($content: JQuery): void => {
     });
 
     $content.find("audio").each(function (): void {
+        // Skip audio we have already transformed. The rendered template below
+        // emits an <audio class="media-audio-element"> inside a wrapper, so a
+        // second update_elements pass on the same content (for example when a
+        // message row is re-rendered) would otherwise match that output and
+        // replace it again, destroying the live element and interrupting
+        // playback. Raw server-rendered audio has no class, so its absence
+        // marks an element as not yet enhanced.
+        if ($(this).hasClass("media-audio-element")) {
+            return;
+        }
+
         // We grab the audio source and title for
         // inserting into the template
         const audio_src = $(this).attr("src");

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -35,6 +35,7 @@ import * as message_live_update from "./message_live_update.ts";
 import * as message_reminder from "./message_reminder.ts";
 import * as message_store from "./message_store.ts";
 import * as message_view from "./message_view.ts";
+import * as miatsuco_dm_authorizer_display from "./miatsuco_dm_authorizer_display.ts";
 import * as muted_users_ui from "./muted_users_ui.ts";
 import * as narrow_title from "./narrow_title.ts";
 import * as navbar_alerts from "./navbar_alerts.ts";
@@ -416,6 +417,14 @@ export function dispatch_normal_event(event) {
                                     settings_org.check_disable_direct_message_initiator_group_widget();
                                     compose_closed_ui.maybe_update_buttons_for_dm_recipient();
                                     compose_validate.validate_and_update_send_button_status();
+                                }
+
+                                if (key === "direct_message_permission_group") {
+                                    // Fork feature (miatsuco): keep the
+                                    // view-only "who can authorize DMs"
+                                    // disclosure in personal preferences in
+                                    // sync when the authorizer group changes.
+                                    miatsuco_dm_authorizer_display.rerender_if_present();
                                 }
 
                                 if (
@@ -977,6 +986,7 @@ export function dispatch_normal_event(event) {
                 "web_mark_read_on_scroll_policy",
                 "web_navigate_to_sent_message",
                 "miatsuco_web_show_upload_thumbnails",
+                "miatsuco_restrict_dms_to_authorizers",
                 "web_stream_unreads_count_display_policy",
                 "web_suggest_update_timezone",
                 "web_left_sidebar_unreads_count_summary",

--- a/web/src/server_events_dispatch.js
+++ b/web/src/server_events_dispatch.js
@@ -315,6 +315,7 @@ export function dispatch_normal_event(event) {
                 digest_weekday: noop,
                 direct_message_initiator_group: noop,
                 direct_message_permission_group: noop,
+                direct_message_self_authorize_group: noop,
                 email_changes_disabled: settings_account.update_email_change_display,
                 disallow_disposable_email_addresses: noop,
                 media_preview_size: message_live_update.update_thumbnails,
@@ -409,7 +410,8 @@ export function dispatch_normal_event(event) {
 
                                 if (
                                     key === "direct_message_initiator_group" ||
-                                    key === "direct_message_permission_group"
+                                    key === "direct_message_permission_group" ||
+                                    key === "direct_message_self_authorize_group"
                                 ) {
                                     settings_org.check_disable_direct_message_initiator_group_widget();
                                     compose_closed_ui.maybe_update_buttons_for_dm_recipient();

--- a/web/src/settings_account.ts
+++ b/web/src/settings_account.ts
@@ -22,6 +22,7 @@ import * as dialog_widget from "./dialog_widget.ts";
 import * as dropdown_widget from "./dropdown_widget.ts";
 import {$t, $t_html} from "./i18n.ts";
 import * as keydown_util from "./keydown_util.ts";
+import * as miatsuco_dm_authorizer_display from "./miatsuco_dm_authorizer_display.ts";
 import * as modals from "./modals.ts";
 import * as overlays from "./overlays.ts";
 import {page_params} from "./page_params.ts";
@@ -353,6 +354,10 @@ export function set_up(): void {
     // Add custom profile fields elements to user account settings.
     add_custom_profile_fields_to_settings();
     $("#account-settings-status").hide();
+
+    // Fork feature (miatsuco): render the read-only "who can authorize DMs"
+    // pills under the miatsuco_restrict_dms_to_authorizers privacy setting.
+    miatsuco_dm_authorizer_display.set_up($("#privacy_settings_box"));
 
     const setup_api_key_modal = (): void => {
         function request_api_key(data: {password?: string}): void {

--- a/web/src/settings_components.ts
+++ b/web/src/settings_components.ts
@@ -901,6 +901,7 @@ export function check_realm_settings_property_changed(elem: HTMLElement): boolea
         case "realm_create_multiuse_invite_group":
         case "realm_direct_message_initiator_group":
         case "realm_direct_message_permission_group":
+        case "realm_direct_message_self_authorize_group":
         case "realm_workplace_users_group": {
             const pill_widget = get_group_setting_widget(property_name);
             assert(pill_widget !== null);
@@ -1163,6 +1164,7 @@ export function populate_data_for_realm_settings_request(
                     "create_multiuse_invite_group",
                     "direct_message_initiator_group",
                     "direct_message_permission_group",
+                    "direct_message_self_authorize_group",
                     "workplace_users_group",
                 ]);
                 if (realm_group_settings.has(property_name)) {
@@ -1692,6 +1694,7 @@ export const group_setting_widget_map = new Map<string, GroupSettingPillContaine
     ["realm_create_multiuse_invite_group", null],
     ["realm_direct_message_initiator_group", null],
     ["realm_direct_message_permission_group", null],
+    ["realm_direct_message_self_authorize_group", null],
     ["realm_workplace_users_group", null],
 ]);
 

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -785,6 +785,10 @@ export const all_group_setting_labels = {
         direct_message_initiator_group: $t({
             defaultMessage: "Who can start a direct message conversation",
         }),
+        direct_message_self_authorize_group: $t({
+            defaultMessage:
+                "Who can direct message others in this setting without an authorizer present",
+        }),
         can_manage_all_groups: $t({defaultMessage: "Who can administer all user groups"}),
         can_manage_billing_group: $t({defaultMessage: "Who can manage plans and billing"}),
         can_create_groups: $t({defaultMessage: "Who can create user groups"}),
@@ -890,7 +894,11 @@ export const realm_group_permission_settings: {
     {
         subsection_heading: $t({defaultMessage: "Direct message permissions"}),
         subsection_key: "org-direct-message-permissions",
-        settings: ["direct_message_permission_group", "direct_message_initiator_group"],
+        settings: [
+            "direct_message_permission_group",
+            "direct_message_initiator_group",
+            "direct_message_self_authorize_group",
+        ],
     },
     {
         subsection_heading: $t({defaultMessage: "Moving messages"}),

--- a/web/src/settings_config.ts
+++ b/web/src/settings_config.ts
@@ -687,6 +687,9 @@ export const preferences_settings_labels = {
     miatsuco_web_show_upload_thumbnails: $t({
         defaultMessage: "Show image, video, and website preview thumbnails",
     }),
+    miatsuco_restrict_dms_to_authorizers: $t({
+        defaultMessage: "Restrict direct messages to only those who can authorize them",
+    }),
     web_left_sidebar_show_channel_folders: $t({
         defaultMessage: "Group channels by folder in the left sidebar",
     }),

--- a/web/src/settings_org.ts
+++ b/web/src/settings_org.ts
@@ -730,6 +730,7 @@ export function discard_realm_property_element_changes(elem: HTMLElement): void 
         case "realm_create_multiuse_invite_group":
         case "realm_direct_message_initiator_group":
         case "realm_direct_message_permission_group":
+        case "realm_direct_message_self_authorize_group":
         case "realm_workplace_users_group": {
             const pill_widget = settings_components.get_group_setting_widget(property_name);
             assert(pill_widget !== null);

--- a/web/src/state_data.ts
+++ b/web/src/state_data.ts
@@ -513,6 +513,7 @@ export const realm_schema = z.object({
     realm_digest_weekday: z.number(),
     realm_direct_message_initiator_group: group_setting_value_schema,
     realm_direct_message_permission_group: group_setting_value_schema,
+    realm_direct_message_self_authorize_group: group_setting_value_schema,
     realm_disallow_disposable_email_addresses: z.boolean(),
     realm_domains: z.array(realm_domain_schema),
     realm_email_auth_enabled: z.boolean(),

--- a/web/src/user_events.ts
+++ b/web/src/user_events.ts
@@ -12,6 +12,8 @@ import * as bot_data from "./bot_data.ts";
 import {buddy_list} from "./buddy_list.ts";
 import * as compose_pm_pill from "./compose_pm_pill.ts";
 import * as compose_recipient from "./compose_recipient.ts";
+import * as compose_state from "./compose_state.ts";
+import * as compose_validate from "./compose_validate.ts";
 import * as message_live_update from "./message_live_update.ts";
 import * as message_view_header from "./message_view_header.ts";
 import * as navbar_alerts from "./navbar_alerts.ts";
@@ -179,6 +181,17 @@ export const update_person = function update(event: UserUpdate): void {
             current_user.is_moderator !== user.is_moderator
         ) {
             current_user.is_moderator = user.is_moderator;
+        }
+
+        // Fork feature (miatsuco): a role change can flip whether an open DM
+        // is still authorized (for example, demoting the only moderator in the
+        // conversation removes the escape hatch, or a role change moves someone
+        // in or out of direct_message_self_authorize_group). Re-validate so the
+        // send button reflects the new state immediately rather than only
+        // failing at send time. validate() no-ops unless the compose box is
+        // open on a DM, so this is cheap for the common case.
+        if (compose_state.get_message_type() === "private") {
+            compose_validate.validate_and_update_send_button_status();
         }
     }
 

--- a/web/src/user_group_popover.ts
+++ b/web/src/user_group_popover.ts
@@ -63,6 +63,12 @@ export function handle_keyboard(key: string): void {
 export function toggle_user_group_info_popover(
     element: tippy.ReferenceElement,
     message_id: number | undefined,
+    // Fork feature (miatsuco): when true, the popover hides navigation into
+    // group administration (the "Group settings" link and the navigating
+    // "View all members" link), leaving a strictly view-only member list. Used
+    // by the personal DM-restriction preference, where the authorizing group
+    // is shown for reference and must not be an entry point to editing.
+    view_only = false,
 ): void {
     if (is_open()) {
         hide();
@@ -131,6 +137,7 @@ export function toggle_user_group_info_popover(
                         settings_data.user_can_access_all_other_users(),
                     displayed_subgroups,
                     displayed_members,
+                    view_only,
                 };
                 instance.setContent(ui_util.parse_html(render_user_group_info_popover(args)));
             },

--- a/web/src/user_settings.ts
+++ b/web/src/user_settings.ts
@@ -85,6 +85,7 @@ export const user_settings_schema = z.object({
     web_mark_read_on_scroll_policy: z.number(),
     web_navigate_to_sent_message: z.boolean(),
     miatsuco_web_show_upload_thumbnails: z.boolean(),
+    miatsuco_restrict_dms_to_authorizers: z.boolean(),
     web_stream_unreads_count_display_policy: z.number(),
     web_suggest_update_timezone: z.boolean(),
 });

--- a/web/styles/rendered_markdown.css
+++ b/web/styles/rendered_markdown.css
@@ -817,15 +817,32 @@
             background: none;
         }
 
-        /* Give the player enough width for the browser's native controls to
-           show the volume slider (browsers collapse it to a mute toggle on
-           narrow players). Portrait videos are letterboxed by object-fit to
-           reach this width. We scale the floor with the organization's media
-           preview size setting rather than hardcoding it, so it tracks
-           --media-preview-max-height (the same basis the landscape width
-           uses) instead of overriding the admin's choice. */
+        /* The preview thumbnail carries a fixed width (see the base
+           .media-video-element rule above), which is fine for a static
+           poster but wrong for a real player: the native control bar is
+           drawn to fill the element's box, so a fixed width makes the
+           player and its controls overflow the message column in narrow or
+           responsive viewports. Make the playable video shrink with its
+           container instead, mirroring how the fork's inline audio player
+           handles the same problem (see .media-audio-element below). */
+        max-width: 100%;
+
         & .media-video-element {
-            min-width: calc(var(--media-preview-max-height) * 1.5);
+            /* The base rule sets a fixed landscape width and height so the
+               static poster has definite dimensions. Keep those as the
+               natural size, but cap the width to the container so a real
+               player and its native control bar shrink with the message
+               column instead of overflowing in narrow or responsive
+               viewports. object-fit (set upstream) letterboxes the frame so
+               it is not distorted as it narrows. */
+            max-width: 100%;
+
+            /* Give the native controls room for the volume slider (browsers
+               collapse it to a mute toggle on narrow players), scaling with
+               the org's media preview size setting. Clamp the floor to the
+               available width with min() so it never forces overflow on a
+               viewport narrower than the floor. */
+            min-width: min(100%, calc(var(--media-preview-max-height) * 1.5));
         }
     }
 

--- a/web/styles/settings.css
+++ b/web/styles/settings.css
@@ -2543,3 +2543,71 @@ label.preferences-radio-choice-label {
     opacity: var(--opacity-disabled-profile-field-choice-input);
     color: var(--color-text-default);
 }
+
+/* MiAtSu.Co fork: the view-only authorizer display under the personal
+   miatsuco_restrict_dms_to_authorizers setting. When the setting is enabled,
+   the current authorizers are shown beneath the checkbox as read-only pills in
+   a bordered container that reuses the editable settings pill look
+   (.pill-container). Visibility follows the checkbox state directly: the pills
+   are only shown while the setting is on. Interaction is limited to opening a
+   view-only members popover on group and role pills, so the pills are not
+   editable. */
+.miatsuco-dm-authorizers {
+    display: none;
+    /* The pills sit inside the setting's own checkbox wrapper, which already
+       carries the spacing between settings, so only a small gap above (below
+       the label) is needed here. */
+    margin: 6px 0 0 24px;
+
+    .miatsuco-dm-authorizers-hint {
+        margin-bottom: 4px;
+        color: var(--color-text-item);
+        font-size: 0.9em;
+    }
+
+    .miatsuco-dm-authorizers-pills {
+        /* The container is informational, not an input. */
+        cursor: default;
+
+        /* Group and role pills open a view-only popover; individual pills are
+           inert. Suppress the persistent focus box-shadow (which otherwise
+           masks the pill background after a click and only clears when focus
+           moves elsewhere) and use a hover/open highlight instead. */
+        .pill {
+            cursor: pointer;
+
+            &:focus {
+                box-shadow: none;
+            }
+
+            &:hover,
+            &[aria-expanded="true"] {
+                background-color: var(--color-background-input-pill-hover);
+            }
+        }
+
+        .pill:not([data-user-group-id]) {
+            /* Individual-user pills are non-interactive. */
+            cursor: default;
+
+            &:hover {
+                background-color: var(--color-background-input-pill);
+            }
+        }
+    }
+
+    .miatsuco-dm-authorizers-empty {
+        font-style: italic;
+        color: var(--color-text-item);
+    }
+}
+
+/* Show the authorizer pills only while the setting itself is enabled. Scoped to
+   this setting's checkbox via its setting-name class so other checkboxes in the
+   shared wrapper are unaffected. */
+.settings-checkbox-wrapper:has(
+        input.miatsuco_restrict_dms_to_authorizers:checked
+    )
+    .miatsuco-dm-authorizers {
+    display: block;
+}

--- a/web/templates/message_controls_failed_msg.hbs
+++ b/web/templates/message_controls_failed_msg.hbs
@@ -1,4 +1,4 @@
-<div class="message_control_button failed_message_action" data-tippy-content="{{t 'Retry' }}">
+<div class="message_control_button failed_message_action" data-tippy-content="{{retry_tooltip}}">
     <i class="message-controls-icon fa fa-refresh refresh-failed-message" aria-label="{{t 'Retry' }}" role="button" tabindex="0"></i>
 </div>
 

--- a/web/templates/popovers/user_group_info_popover.hbs
+++ b/web/templates/popovers/user_group_info_popover.hbs
@@ -48,22 +48,26 @@
                     {{#unless display_all_subgroups_and_members}}
                         <li class="popover-group-menu-member">
                             <span class="popover-group-menu-member-name">
-                                {{#if is_system_group}}
-                                    {{#if has_bots}}
-                                        {{#tr class="popover-group-menu-member"}}
-                                            View all <z-link-users>users</z-link-users> and <z-link-bots>bots</z-link-bots>
-                                            {{#*inline "z-link-users"}}<a href="#organization/users">{{> @partial-block}}</a>{{/inline}}
-                                            {{#*inline "z-link-bots"}}<a href="#organization/bots">{{> @partial-block}}</a>{{/inline}}
-                                        {{/tr}}
+                                {{#if view_only}}
+                                    <i>{{t "Additional members not shown"}}</i>
+                                {{else}}
+                                    {{#if is_system_group}}
+                                        {{#if has_bots}}
+                                            {{#tr class="popover-group-menu-member"}}
+                                                View all <z-link-users>users</z-link-users> and <z-link-bots>bots</z-link-bots>
+                                                {{#*inline "z-link-users"}}<a href="#organization/users">{{> @partial-block}}</a>{{/inline}}
+                                                {{#*inline "z-link-bots"}}<a href="#organization/bots">{{> @partial-block}}</a>{{/inline}}
+                                            {{/tr}}
+                                        {{else}}
+                                            <a href="#organization/users" role="menuitem">
+                                                {{t "View all users"}}
+                                            </a>
+                                        {{/if}}
                                     {{else}}
-                                        <a href="#organization/users" role="menuitem">
-                                            {{t "View all users"}}
+                                        <a href="{{group_members_url}}" role="menuitem">
+                                            {{t "View all members"}}
                                         </a>
                                     {{/if}}
-                                {{else}}
-                                    <a href="{{group_members_url}}" role="menuitem">
-                                        {{t "View all members"}}
-                                    </a>
                                 {{/if}}
                             </span>
                         </li>
@@ -73,6 +77,7 @@
                 <span class="popover-group-menu-placeholder"><i>{{t 'This group has no members.'}}</i></span>
             {{/unless}}
         </li>
+        {{#unless view_only}}
         {{#unless is_guest}}
             <li role="separator" class="popover-menu-separator hidden-for-spectators"></li>
             <li role="none" class="link-item popover-menu-list-item hidden-for-spectators">
@@ -81,6 +86,7 @@
                     <span class="popover-menu-label">{{t "Group settings" }}</span>
                 </a>
             </li>
+        {{/unless}}
         {{/unless}}
     </ul>
 </div>

--- a/web/templates/settings/organization_permissions_admin.hbs
+++ b/web/templates/settings/organization_permissions_admin.hbs
@@ -140,6 +140,10 @@
             {{> group_setting_value_pill_input
               setting_name="realm_direct_message_initiator_group"
               label=group_setting_labels.direct_message_initiator_group}}
+
+            {{> group_setting_value_pill_input
+              setting_name="realm_direct_message_self_authorize_group"
+              label=group_setting_labels.direct_message_self_authorize_group}}
         </div>
 
         <div id="org-msg-editing" class="settings-subsection-parent">

--- a/web/templates/settings/privacy_settings.hbs
+++ b/web/templates/settings/privacy_settings.hbs
@@ -22,6 +22,15 @@
       label=settings_label.send_stream_typing_notifications
       prefix=prefix
       }}
+    {{#unless for_realm_settings}}
+    {{> settings_checkbox
+      setting_name="miatsuco_restrict_dms_to_authorizers"
+      is_checked=settings_object.miatsuco_restrict_dms_to_authorizers
+      label=settings_label.miatsuco_restrict_dms_to_authorizers
+      post_setting_content_class="miatsuco-dm-authorizers"
+      prefix=prefix
+      }}
+    {{/unless}}
     {{> settings_checkbox
       setting_name="send_read_receipts"
       is_checked=settings_object.send_read_receipts

--- a/web/templates/settings/settings_checkbox.hbs
+++ b/web/templates/settings/settings_checkbox.hbs
@@ -20,5 +20,8 @@
         {{> ../components/icon_button icon="reset" intent="neutral" custom_classes="reset-user-setting-to-default" data-tippy-content=(t "Reset users to default") aria-label=(t "Reset users to default") }}
         {{/if}}
     </label>
+    {{#if post_setting_content_class}}
+    <div class="{{post_setting_content_class}}"></div>
+    {{/if}}
 </div>
 {{/unless}}

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -378,6 +378,17 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
     (function test_param_error_function_passed_from_send_message() {
         stub_state = initialize_state_stub_dict();
 
+        // The locally-echoed failure path now also surfaces the reason as a
+        // compose banner, so the sender sees it even on touch devices where the
+        // message-row tooltip is not reachable.
+        let banner_rendered = false;
+        mock_template("compose_banner/compose_banner.hbs", false, (data) => {
+            assert.equal(data.classname, "generic_compose_error");
+            assert.equal(data.banner_text, "Error sending message: Server says 408");
+            banner_rendered = true;
+            return "<banner-stub>";
+        });
+
         compose.send_message();
 
         const state = {
@@ -387,6 +398,7 @@ test_ui("send_message", ({override, override_rewire, mock_template}) => {
         };
         assert.deepEqual(stub_state, state);
         assert.ok(echo_error_msg_checked);
+        assert.ok(banner_rendered);
     })();
 
     (function test_error_codepath_local_id_undefined() {

--- a/web/tests/compose.test.cjs
+++ b/web/tests/compose.test.cjs
@@ -520,6 +520,7 @@ test_ui("finish", ({override, override_rewire}) => {
         override(compose_pm_pill, "get_user_ids", () => [bob.user_id]);
         override(realm, "realm_direct_message_permission_group", everyone.id);
         override(realm, "realm_direct_message_initiator_group", everyone.id);
+        override(realm, "realm_direct_message_self_authorize_group", nobody.id);
 
         let send_message_called = false;
         override_rewire(compose, "send_message", () => {
@@ -847,6 +848,7 @@ test_ui("DM policy disabled", ({override}) => {
     // Disable sending direct messages in the organisation
     override(realm, "realm_direct_message_permission_group", nobody.id);
     override(realm, "realm_direct_message_initiator_group", everyone.id);
+    override(realm, "realm_direct_message_self_authorize_group", nobody.id);
     // For single bot recipient, Bot, the "Message X" button is not disabled
     let reply_disabled =
         compose_closed_ui.should_disable_compose_reply_button_for_direct_message("33");

--- a/web/tests/compose_actions.test.cjs
+++ b/web/tests/compose_actions.test.cjs
@@ -346,6 +346,7 @@ test("respond_to_message", ({override, override_rewire, mock_template}) => {
 
     override(realm, "realm_direct_message_permission_group", nobody.id);
     override(realm, "realm_direct_message_initiator_group", everyone.id);
+    override(realm, "realm_direct_message_self_authorize_group", nobody.id);
 
     override_rewire(stream_data, "can_post_messages_in_stream", () => true);
 
@@ -471,6 +472,7 @@ test("quote_messages", ({disallow, override, override_rewire}) => {
 
     override(realm, "realm_direct_message_permission_group", nobody.id);
     override(realm, "realm_direct_message_initiator_group", everyone.id);
+    override(realm, "realm_direct_message_self_authorize_group", nobody.id);
 
     mock_banners();
     compose_state.set_message_type("stream");
@@ -1057,6 +1059,7 @@ test("on_narrow", ({override, override_rewire}) => {
     narrowed_by_pm_reply = true;
     override(realm, "realm_direct_message_permission_group", nobody.id);
     override(realm, "realm_direct_message_initiator_group", everyone.id);
+    override(realm, "realm_direct_message_self_authorize_group", nobody.id);
     let compose_defaults;
     override(narrow_state, "set_compose_defaults", () => compose_defaults);
     compose_defaults = {

--- a/web/tests/compose_validate.test.cjs
+++ b/web/tests/compose_validate.test.cjs
@@ -187,6 +187,7 @@ test_ui("validate", ({mock_template, override}) => {
     let pm_recipient_error_rendered = false;
     override(realm, "realm_direct_message_permission_group", everyone.id);
     override(realm, "realm_direct_message_initiator_group", everyone.id);
+    override(realm, "realm_direct_message_self_authorize_group", nobody.id);
     mock_template("compose_banner/compose_banner.hbs", false, (data) => {
         assert.equal(data.classname, compose_banner.CLASSNAMES.missing_private_message_recipient);
         assert.equal(data.banner_text, compose_validate.NO_PRIVATE_RECIPIENT_ERROR_MESSAGE);

--- a/web/tests/composebox_typeahead.test.cjs
+++ b/web/tests/composebox_typeahead.test.cjs
@@ -2143,6 +2143,7 @@ test("get_person_suggestion_for_topic_typeahead respects DM permissions", ({over
     // Bot suggestion doesn't show up if there is no past conversation.
     override(realm, "realm_direct_message_permission_group", nobody.id);
     override(realm, "realm_direct_message_initiator_group", nobody.id);
+    override(realm, "realm_direct_message_self_authorize_group", nobody.id);
     let results = ct.get_person_suggestion_for_topic_typeahead("notification");
     assert.deepEqual(results, []);
 
@@ -3250,6 +3251,7 @@ test("get_pm_people respects DM permissions", ({override}) => {
     // When DMs are disabled realm-wide, lear should not appear in suggestions.
     override(realm, "realm_direct_message_permission_group", nobody.id);
     override(realm, "realm_direct_message_initiator_group", nobody.id);
+    override(realm, "realm_direct_message_self_authorize_group", nobody.id);
     let results = ct.get_pm_people("king lear");
     assert.deepEqual(results, []);
 

--- a/web/tests/dispatch.test.cjs
+++ b/web/tests/dispatch.test.cjs
@@ -81,6 +81,7 @@ const settings_notifications = mock_esm("../src/settings_notifications");
 const settings_org = mock_esm("../src/settings_org");
 const settings_profile_fields = mock_esm("../src/settings_profile_fields");
 const settings_preferences = mock_esm("../src/settings_preferences");
+const miatsuco_dm_authorizer_display = mock_esm("../src/miatsuco_dm_authorizer_display");
 const settings_realm_user_settings_defaults = mock_esm(
     "../src/settings_realm_user_settings_defaults",
 );
@@ -671,6 +672,7 @@ run_test("realm settings", ({override}) => {
     override(realm, "realm_date_created", new Date("2023-01-01Z"));
 
     override(settings_org, "check_disable_direct_message_initiator_group_widget", noop);
+    override(miatsuco_dm_authorizer_display, "rerender_if_present", noop);
     override(settings_org, "sync_realm_settings", noop);
     override(settings_bots, "update_bot_permissions_ui", noop);
     override(settings_emoji, "update_custom_emoji_ui", noop);
@@ -1362,6 +1364,15 @@ run_test("user_settings", ({override}) => {
         assert_same(user_settings.miatsuco_web_show_upload_thumbnails, false);
         assert_same(called, true);
         assert_same(called_for_cached_msg_list, true);
+    }
+
+    {
+        // MiAtSu.Co fork: toggling the personal restrict-DMs preference
+        // updates the setting value; no message rerender is needed.
+        event = event_fixtures.user_settings__miatsuco_restrict_dms_to_authorizers;
+        override(user_settings, "miatsuco_restrict_dms_to_authorizers", false);
+        dispatch(event);
+        assert_same(user_settings.miatsuco_restrict_dms_to_authorizers, true);
     }
 
     {

--- a/web/tests/lib/events.cjs
+++ b/web/tests/lib/events.cjs
@@ -1135,6 +1135,13 @@ exports.fixtures = {
         value: true,
     },
 
+    user_settings__miatsuco_restrict_dms_to_authorizers: {
+        type: "user_settings",
+        op: "update",
+        property: "miatsuco_restrict_dms_to_authorizers",
+        value: true,
+    },
+
     user_settings__miatsuco_web_show_upload_thumbnails: {
         type: "user_settings",
         op: "update",

--- a/web/tests/lib/example_realm.cjs
+++ b/web/tests/lib/example_realm.cjs
@@ -73,6 +73,7 @@ exports.make_realm = (opts = {}) => {
         realm_digest_emails_enabled: false,
         realm_digest_weekday: 0,
         realm_direct_message_initiator_group: 0,
+        realm_direct_message_self_authorize_group: 0,
         realm_direct_message_permission_group: 0,
         realm_disallow_disposable_email_addresses: false,
         realm_domains: [],

--- a/web/tests/lib/example_settings.cjs
+++ b/web/tests/lib/example_settings.cjs
@@ -324,6 +324,15 @@ exports.server_supported_permission_settings = {
             default_for_system_groups: null,
             allowed_system_groups: [],
         },
+        direct_message_self_authorize_group: {
+            require_system_group: false,
+            allow_internet_group: false,
+            allow_nobody_group: true,
+            allow_everyone_group: true,
+            default_group_name: "role:nobody",
+            default_for_system_groups: null,
+            allowed_system_groups: [],
+        },
     },
     group: {
         can_add_members_group: {

--- a/web/tests/message_view.test.cjs
+++ b/web/tests/message_view.test.cjs
@@ -418,6 +418,7 @@ run_test("show_empty_narrow_message", ({mock_template, override, override_rewire
 
     override(realm, "realm_direct_message_permission_group", everyone.id);
     override(realm, "realm_direct_message_initiator_group", everyone.id);
+    override(realm, "realm_direct_message_self_authorize_group", nobody.id);
     current_filter = set_filter([["is", "dm"]]);
     narrow_banner.show_empty_narrow_message(current_filter);
     assert.equal(

--- a/web/tests/miatsuco_dm_authorizer_display.test.cjs
+++ b/web/tests/miatsuco_dm_authorizer_display.test.cjs
@@ -1,0 +1,161 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {make_user_group} = require("./lib/example_group.cjs");
+const {make_realm} = require("./lib/example_realm.cjs");
+const {make_user} = require("./lib/example_user.cjs");
+const {mock_esm, zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+const $ = require("./lib/zjquery.cjs");
+
+const user_group_popover = mock_esm("../src/user_group_popover");
+
+const user_groups = zrequire("user_groups");
+const people = zrequire("people");
+const {set_realm} = zrequire("state_data");
+const miatsuco_dm_authorizer_display = zrequire("miatsuco_dm_authorizer_display");
+
+const realm = make_realm({});
+set_realm(realm);
+
+const alice = make_user({email: "alice@example.com", user_id: 11, full_name: "Alice"});
+const bob = make_user({email: "bob@example.com", user_id: 12, full_name: "Bob"});
+people.add_active_user(alice);
+people.add_active_user(bob);
+
+const moderators = make_user_group({
+    name: "role:moderators",
+    id: 100,
+    members: new Set([alice.user_id]),
+});
+user_groups.initialize({realm_user_groups: [moderators]});
+
+run_test("group value renders a clickable group pill", () => {
+    const html = miatsuco_dm_authorizer_display.build_pills_html(moderators.id);
+    // A group pill carries data-user-group-id so it opens the popover.
+    assert.ok(html.includes(`data-user-group-id="${moderators.id}"`));
+    // It should not carry a user-id target.
+    assert.ok(!html.includes("data-user-id="));
+});
+
+run_test("individual member renders a non-interactive user pill", () => {
+    const value = {direct_subgroups: [], direct_members: [alice.user_id]};
+    const html = miatsuco_dm_authorizer_display.build_pills_html(value);
+    // The name is shown, but with no data-user-group-id and no data-user-id,
+    // so the pill is purely informational.
+    assert.ok(html.includes("Alice"));
+    assert.ok(!html.includes("data-user-group-id="));
+    assert.ok(!html.includes("data-user-id="));
+});
+
+run_test("anonymous combination renders both group and user pills", () => {
+    const value = {direct_subgroups: [moderators.id], direct_members: [bob.user_id]};
+    const html = miatsuco_dm_authorizer_display.build_pills_html(value);
+    assert.ok(html.includes(`data-user-group-id="${moderators.id}"`));
+    assert.ok(html.includes("Bob"));
+});
+
+run_test("empty value renders no pills", () => {
+    const value = {direct_subgroups: [], direct_members: []};
+    const html = miatsuco_dm_authorizer_display.build_pills_html(value);
+    assert.equal(html, "");
+});
+
+run_test("unknown group id is skipped", () => {
+    const html = miatsuco_dm_authorizer_display.build_pills_html(9999);
+    assert.equal(html, "");
+});
+
+run_test("unknown individual member id is skipped", () => {
+    const value = {direct_subgroups: [], direct_members: [999_999]};
+    const html = miatsuco_dm_authorizer_display.build_pills_html(value);
+    assert.equal(html, "");
+});
+
+run_test("render_pills populates the pill container", ({override}) => {
+    override(realm, "realm_direct_message_permission_group", moderators.id);
+    const $pills = $.create("pills");
+    const $container = $.create("render-container");
+    $container.set_find_results(".miatsuco-dm-authorizers-pills", $pills);
+
+    miatsuco_dm_authorizer_display.render_pills($container);
+
+    assert.ok($pills.html().includes(`data-user-group-id="${moderators.id}"`));
+});
+
+run_test("render_pills shows an empty message when no one can authorize", ({override}) => {
+    override(realm, "realm_direct_message_permission_group", {
+        direct_subgroups: [],
+        direct_members: [],
+    });
+    const $pills = $.create("empty-pills");
+    const $container = $.create("empty-container");
+    $container.set_find_results(".miatsuco-dm-authorizers-pills", $pills);
+
+    // Should not throw; the empty-state span is appended.
+    miatsuco_dm_authorizer_display.render_pills($container);
+});
+
+run_test("render_pills is a no-op without a pill container", () => {
+    const $container = $.create("no-pills-container");
+    $container.set_find_results(".miatsuco-dm-authorizers-pills", []);
+    // Should not throw.
+    miatsuco_dm_authorizer_display.render_pills($container);
+});
+
+run_test("set_up mounts the pill container and wires the popover handler", ({override}) => {
+    override(realm, "realm_direct_message_permission_group", moderators.id);
+
+    const $pills = $.create("setup-pills");
+    const $disclosure = $.create("disclosure");
+    const $container = $.create("setup-container");
+    $container.set_find_results(".miatsuco-dm-authorizers", $disclosure);
+    $container.set_find_results(".miatsuco-dm-authorizers-pills", $pills);
+
+    miatsuco_dm_authorizer_display.set_up($container);
+
+    const popover_handler = $disclosure.get_on_handler(
+        "click",
+        ".miatsuco-dm-authorizers-pills .pill[data-user-group-id]",
+    );
+    assert.ok(popover_handler !== undefined);
+
+    // Invoke the popover handler to cover the view-only popover call.
+    let popover_opened_view_only = false;
+    override(user_group_popover, "toggle_user_group_info_popover", (_el, _msg, view_only) => {
+        popover_opened_view_only = view_only;
+    });
+    const $pill = $.create("pill-target");
+    const event = {stopPropagation() {}};
+    popover_handler.call($pill.get(0) ?? $pill, event);
+    assert.ok(popover_opened_view_only);
+});
+
+run_test("rerender_if_present updates the settings panel when open", ({override}) => {
+    override(realm, "realm_direct_message_permission_group", moderators.id);
+    const $pills = $.create("live-pills");
+    $.reset_selector("#settings_content");
+    const $settings = $.create("#settings_content");
+    $settings.set_find_results(".miatsuco-dm-authorizers-pills", $pills);
+
+    miatsuco_dm_authorizer_display.rerender_if_present();
+
+    assert.ok($pills.html().includes(`data-user-group-id="${moderators.id}"`));
+    $.clear_all_elements();
+});
+
+run_test("rerender_if_present is a no-op when settings are closed", () => {
+    $.reset_selector("#settings_content");
+    $.set_results("#settings_content", []);
+    // Should not throw and should not attempt to find the pill container.
+    miatsuco_dm_authorizer_display.rerender_if_present();
+    $.clear_all_elements();
+});
+
+run_test("set_up is a no-op without a disclosure element", () => {
+    const $container = $.create("no-disclosure-container");
+    $container.set_find_results(".miatsuco-dm-authorizers", []);
+    // Should not throw and should not require a pill container.
+    miatsuco_dm_authorizer_display.set_up($container);
+});

--- a/web/tests/miatsuco_dm_self_authorize.test.cjs
+++ b/web/tests/miatsuco_dm_self_authorize.test.cjs
@@ -1,0 +1,67 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+
+const {make_realm} = require("./lib/example_realm.cjs");
+const {make_user} = require("./lib/example_user.cjs");
+const {zrequire} = require("./lib/namespace.cjs");
+const {run_test} = require("./lib/test.cjs");
+
+const people = zrequire("people");
+const {set_realm} = zrequire("state_data");
+
+// Fork feature (miatsuco): direct_message_self_authorize_group lets a
+// configured set exchange DMs among themselves without a permission-group
+// member present. This exercises the client-side branch in
+// people.user_can_direct_message that mirrors the backend allowance.
+
+const realm = make_realm({});
+set_realm(realm);
+
+const me = make_user({email: "me@example.com", user_id: 1, full_name: "Me"});
+const peer = make_user({email: "peer@example.com", user_id: 2, full_name: "Peer"});
+const outsider = make_user({email: "outsider@example.com", user_id: 3, full_name: "Outsider"});
+const bot = make_user({email: "bot@example.com", user_id: 4, full_name: "Bot", is_bot: true});
+
+people.init();
+for (const user of [me, peer, outsider, bot]) {
+    people.add_active_user(user);
+}
+people.initialize_current_user(me.user_id);
+
+// A DM never uses the permission-group escape hatch in these cases: the
+// current user is not in it, so the self-authorize branch is what decides.
+function set_groups({self_authorize_members}) {
+    // Anonymous-group form: an object with explicit direct_members. Nobody is
+    // in the permission group, forcing evaluation of the self-authorize path.
+    realm.realm_direct_message_permission_group = {direct_members: [], direct_subgroups: []};
+    realm.realm_direct_message_self_authorize_group = {
+        direct_members: self_authorize_members,
+        direct_subgroups: [],
+    };
+}
+
+run_test("self_authorize allows DMs among members", () => {
+    // Me and the peer are both in the self-authorize group; a DM between us is
+    // authorized without a permission-group member present.
+    set_groups({self_authorize_members: [me.user_id, peer.user_id]});
+    assert.ok(people.user_can_direct_message(peer.user_id.toString()));
+
+    // Bots and the sender are skipped, so a DM to the peer plus a bot is still
+    // authorized as long as every other human is a self-authorizer.
+    assert.ok(people.user_can_direct_message(`${peer.user_id},${bot.user_id},${me.user_id}`));
+});
+
+run_test("self_authorize blocks when any recipient is outside the group", () => {
+    // Me and the peer self-authorize, but the outsider does not. A DM that
+    // includes the outsider is not authorized by the self-authorize path.
+    set_groups({self_authorize_members: [me.user_id, peer.user_id]});
+    assert.ok(!people.user_can_direct_message(`${peer.user_id},${outsider.user_id}`));
+});
+
+run_test("self_authorize path is skipped when sender is not a member", () => {
+    // If the current user is not in the self-authorize group, the branch does
+    // not apply and cannot authorize the DM on its own.
+    set_groups({self_authorize_members: [peer.user_id]});
+    assert.ok(!people.user_can_direct_message(peer.user_id.toString()));
+});

--- a/web/tests/miatsuco_inline_video.test.cjs
+++ b/web/tests/miatsuco_inline_video.test.cjs
@@ -3,7 +3,7 @@
 const assert = require("node:assert/strict");
 
 const {zrequire} = require("./lib/namespace.cjs");
-const {run_test} = require("./lib/test.cjs");
+const {run_test, noop} = require("./lib/test.cjs");
 const $ = require("./lib/zjquery.cjs");
 
 const miatsuco_inline_video = zrequire("miatsuco_inline_video");
@@ -50,6 +50,10 @@ run_test("enhances a playable inline video", () => {
     const $anchor = $.create("anchor-element");
     $container.set_find_results("video", $video);
     $container.set_find_results("a", $anchor);
+    // A real video element exposes canPlayType; a playable file reports a
+    // non-empty result, so enhancement proceeds.
+    $video.attr("src", "https://example.com/uploads/clip.webm");
+    $video[0].canPlayType = () => "probably";
 
     miatsuco_inline_video.enhance_inline_videos(make_content($container));
 
@@ -82,4 +86,60 @@ run_test("enhances a playable inline video", () => {
     };
     $anchor.get_on_handler("click")(anchor_event);
     assert.equal(anchor_event.prevent_default_calls, 1);
+});
+
+run_test("falls back when the browser cannot play the container", () => {
+    const $container = $.create("video-container");
+    const $video = $.create("video-element");
+    const $anchor = $.create("anchor-element");
+    $container.set_find_results("video", $video);
+    $container.set_find_results("a", $anchor);
+    $video.attr("src", "https://example.com/uploads/clip.mov");
+    // The browser reports a definitive "cannot play" for this container.
+    $video[0].canPlayType = () => "";
+
+    miatsuco_inline_video.enhance_inline_videos(make_content($container));
+
+    // The preview is marked unsupported (hidden, download link remains) and
+    // never turned into a player.
+    assert.ok($container.hasClass("video-format-unsupported"));
+    assert.equal($container.attr("data-miatsuco-inline-video"), undefined);
+    assert.ok(!$container.hasClass("miatsuco-inline-video-playable"));
+});
+
+run_test("enhances when the browser might play the container", () => {
+    const $container = $.create("video-container");
+    const $video = $.create("video-element");
+    const $anchor = $.create("anchor-element");
+    $container.set_find_results("video", $video);
+    $container.set_find_results("a", $anchor);
+    $video.attr("src", "https://example.com/uploads/clip.mp4?v=2");
+    // "maybe" (and "probably") are not definitive, so we proceed.
+    $video[0].canPlayType = () => "maybe";
+
+    miatsuco_inline_video.enhance_inline_videos(make_content($container));
+
+    assert.ok(!$container.hasClass("video-format-unsupported"));
+    assert.equal($container.attr("data-miatsuco-inline-video"), "1");
+    assert.ok($container.hasClass("miatsuco-inline-video-playable"));
+});
+
+run_test("enhances when the extension is unrecognized", () => {
+    const $container = $.create("video-container");
+    const $video = $.create("video-element");
+    const $anchor = $.create("anchor-element");
+    $container.set_find_results("video", $video);
+    $container.set_find_results("a", $anchor);
+    // No recognizable extension, so there is no container type to check;
+    // canPlayType is left as noop (its presence lets the capability check run,
+    // but an unrecognized extension means it is never consulted) and
+    // enhancement proceeds, leaving a genuine failure to the error-event
+    // fallback.
+    $video.attr("src", "https://example.com/uploads/clip");
+    $video[0].canPlayType = noop;
+
+    miatsuco_inline_video.enhance_inline_videos(make_content($container));
+
+    assert.ok(!$container.hasClass("video-format-unsupported"));
+    assert.equal($container.attr("data-miatsuco-inline-video"), "1");
 });

--- a/web/tests/rendered_markdown.test.cjs
+++ b/web/tests/rendered_markdown.test.cjs
@@ -220,6 +220,47 @@ run_test("message_inline_video_unsupported_format", () => {
     assert.ok($video_container.hasClass("video-format-unsupported"));
 });
 
+run_test("message_inline_video_unsupported_format_after_fork_enhance", () => {
+    // The fork turns inline video previews into real players (adds controls,
+    // the playable marker class). This must not disturb upstream's fallback:
+    // if playback then fails, the error handler should still hide the broken
+    // player via video-format-unsupported (CSS display:none), leaving the
+    // download link. Exercise both on the same element: enhance runs from
+    // update_elements, then a media error must still add the fallback class.
+    const $content = get_content_element();
+    const $video = $.create("video_element");
+    const $video_container = $.create("message_inline_video_container");
+    const $anchor = $.create("anchor_element");
+
+    // Wire the upstream error handler (matches ".message_inline_video video")
+    // and the fork enhancer (matches ".message_inline_video" containers) onto
+    // the same elements.
+    $video.set_closest_results(".message_inline_video", $video_container);
+    $content.set_find_results(".message_inline_video video", $video);
+    $content.set_find_results(".message_inline_video", $video_container);
+    $video_container.set_find_results("video", $video);
+    $video_container.set_find_results("a", $anchor);
+    // The container is playable enough to be enhanced (a non-empty
+    // canPlayType), so the fork turns it into a player; the error only comes
+    // later, at playback time.
+    $video.attr("src", "https://example.com/uploads/clip.webm");
+    $video[0].canPlayType = () => "probably";
+
+    rm.update_elements($content);
+
+    // The fork enhancement ran: the preview is now a marked player.
+    assert.equal($video_container.attr("data-miatsuco-inline-video"), "1");
+    assert.equal($video.attr("controls"), "true");
+    assert.ok($video_container.hasClass("miatsuco-inline-video-playable"));
+
+    // A later playback failure still triggers the fallback: the container is
+    // marked unsupported so the broken player is hidden and the download link
+    // remains reachable.
+    assert.ok(!$video_container.hasClass("video-format-unsupported"));
+    $video.trigger("error");
+    assert.ok($video_container.hasClass("video-format-unsupported"));
+});
+
 run_test("user-mention", ({override}) => {
     // Setup
     const $content = get_content_element();
@@ -752,6 +793,26 @@ run_test("audio error hides the player", () => {
     const error_handler = $audio.get_on_handler("error");
     error_handler();
     assert.ok($audio.hasClass("miatsuco-audio-format-unsupported"));
+});
+
+run_test("audio already enhanced is not replaced again", () => {
+    // A second update_elements pass on already-transformed content must not
+    // re-replace the audio, which would destroy a playing element and stop
+    // playback. Enhanced audio carries the media-audio-element class (raw
+    // server audio does not), so it is skipped and the template that would
+    // rebuild it is never rendered.
+    const $content = get_content_element();
+    const $audio = $.create("audio");
+    $audio.addClass("media-audio-element");
+    // Deliberately do not stub replaceWith: if the guard failed and the code
+    // tried to rebuild this element, the mock would throw on the unknown
+    // property and fail the test.
+    $content.set_find_results("audio", $audio);
+
+    rm.update_elements($content);
+
+    // Still the original element (not replaced), so playback would survive.
+    assert.ok($audio.hasClass("media-audio-element"));
 });
 
 run_test("timestamp", ({mock_template}) => {

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -1653,6 +1653,53 @@ def check_can_send_direct_message(
             realm.direct_message_permission_group_id, participant_ids
         )
 
+    # Fork feature (miatsuco): the personal miatsuco_restrict_dms_to_authorizers
+    # setting. A participant who enables it opts out of any direct message that
+    # includes a non-authorizer: for that user, EVERY other human participant
+    # must be a member of direct_message_permission_group (an authorizer). This
+    # is stricter than merely requiring an authorizer to be present, and it
+    # overrides the self-authorize path below. It is bidirectional and applies
+    # per participant: it governs an opted-in user's outgoing DMs as well as
+    # incoming ones (a DM is a two-way conversation), and a fellow opted-in user
+    # is not an exception (a non-authorizer is still a non-authorizer). Bots are
+    # not subject to authorization, so they are ignored here.
+    permission_group_id = realm.direct_message_permission_group_id
+    permission_group_is_system = permission_group_id in system_groups_name_dict
+
+    def is_authorizer(user: UserProfile) -> bool:
+        if permission_group_is_system:
+            return check_user_has_permission_by_role(
+                user, permission_group_id, system_groups_name_dict
+            )
+        return is_user_in_group(permission_group_id, user)
+
+    human_participants = [user for user in participants if not user.is_bot]
+    opted_in_participants = [
+        user for user in human_participants if user.miatsuco_restrict_dms_to_authorizers
+    ]
+    if opted_in_participants:
+        # For each opted-in user, every OTHER human participant must be an
+        # authorizer. Equivalently: block if any opted-in user shares the
+        # conversation with a human who cannot authorize it (other than
+        # themselves).
+        for opted_in_user in opted_in_participants:
+            if any(
+                other.id != opted_in_user.id and not is_authorizer(other)
+                for other in human_participants
+            ):
+                # Use the singular "this user" message only when exactly one
+                # recipient (not the sender) triggered the block, so no
+                # individual is named in a group conversation and the sender's
+                # own restriction reads sensibly.
+                opted_in_recipients = [
+                    user for user in opted_in_participants if user.id != sender.id
+                ]
+                restricted_recipient_count = 1 if len(opted_in_recipients) == 1 else 2
+                raise DirectMessagePermissionError(
+                    is_nobody_group=False,
+                    restricted_recipient_count=restricted_recipient_count,
+                )
+
     # Only evaluate the self-authorize path when the permission group did not
     # authorize the conversation, to avoid a membership query per participant
     # in the common case.

--- a/zerver/actions/message_send.py
+++ b/zerver/actions/message_send.py
@@ -89,6 +89,7 @@ from zerver.lib.user_groups import (
     check_user_has_permission_by_role,
     is_any_user_in_group,
     is_user_in_group,
+    user_has_permission_for_group_setting,
 )
 from zerver.lib.user_message import UserMessageLite, bulk_insert_ums
 from zerver.lib.users import (
@@ -1632,20 +1633,44 @@ def check_can_send_direct_message(
         return
 
     system_groups_name_dict = get_realm_system_groups_name_dict(realm.id)
+
+    participants = set(recipient_users) | {sender}
+
+    # Fork feature (miatsuco): a direct message is authorized if a member of
+    # direct_message_permission_group is present (the upstream rule, which the
+    # mod escape hatch relies on), OR if every participant is in the
+    # direct_message_self_authorize_group. That self-authorize path lets a
+    # configured set (for example a "group 1") exchange DMs among themselves
+    # without needing a permission-group member, while any participant outside
+    # that set still requires one.
     if realm.direct_message_permission_group_id in system_groups_name_dict:
-        users = set(recipient_users) | {sender}
-        if not check_any_user_has_permission_by_role(
-            users, realm.direct_message_permission_group_id, system_groups_name_dict
-        ):
-            is_nobody_group = (
-                system_groups_name_dict[realm.direct_message_permission_group_id]
-                == SystemGroups.NOBODY
-            )
-            raise DirectMessagePermissionError(is_nobody_group)
+        permission_group_member_present = check_any_user_has_permission_by_role(
+            participants, realm.direct_message_permission_group_id, system_groups_name_dict
+        )
     else:
-        user_ids = {recipient_user.id for recipient_user in recipient_users} | {sender.id}
-        if not is_any_user_in_group(realm.direct_message_permission_group_id, user_ids):
-            raise DirectMessagePermissionError(is_nobody_group=False)
+        participant_ids = {user.id for user in participants}
+        permission_group_member_present = is_any_user_in_group(
+            realm.direct_message_permission_group_id, participant_ids
+        )
+
+    # Only evaluate the self-authorize path when the permission group did not
+    # authorize the conversation, to avoid a membership query per participant
+    # in the common case.
+    all_participants_can_self_authorize = permission_group_member_present or all(
+        user_has_permission_for_group_setting(
+            realm.direct_message_self_authorize_group_id,
+            user,
+            Realm.REALM_PERMISSION_GROUP_SETTINGS["direct_message_self_authorize_group"],
+        )
+        for user in participants
+    )
+
+    if not (permission_group_member_present or all_participants_can_self_authorize):
+        is_nobody_group = (
+            system_groups_name_dict.get(realm.direct_message_permission_group_id)
+            == SystemGroups.NOBODY
+        )
+        raise DirectMessagePermissionError(is_nobody_group)
 
     if realm.direct_message_initiator_group_id in system_groups_name_dict:
         if check_user_has_permission_by_role(

--- a/zerver/lib/event_types.py
+++ b/zerver/lib/event_types.py
@@ -640,6 +640,7 @@ class GroupSettingUpdateData(GroupSettingUpdateDataCore):
     can_summarize_topics_group: int | UserGroupMembersDict | None = None
     direct_message_initiator_group: int | UserGroupMembersDict | None = None
     direct_message_permission_group: int | UserGroupMembersDict | None = None
+    direct_message_self_authorize_group: int | UserGroupMembersDict | None = None
     workplace_users_group: int | UserGroupMembersDict | None = None
 
 

--- a/zerver/lib/exceptions.py
+++ b/zerver/lib/exceptions.py
@@ -609,8 +609,26 @@ class CannotSetTopicsPolicyError(JsonableError):
 
 
 class DirectMessagePermissionError(JsonableError):
-    def __init__(self, is_nobody_group: bool) -> None:
-        if is_nobody_group:
+    def __init__(
+        self, is_nobody_group: bool, *, restricted_recipient_count: int | None = None
+    ) -> None:
+        # Fork feature (miatsuco): restricted_recipient_count is set when the
+        # block is caused by one or more recipients enabling the personal
+        # "only receive direct messages from those who can authorize them"
+        # setting (miatsuco_restrict_dms_to_authorizers). In that case we surface
+        # a distinct, actionable message instead of the generic authorizer error,
+        # so the sender understands the conversation needs an authorizer because
+        # of the recipient's preference. The wording avoids naming a specific
+        # recipient in group conversations.
+        if restricted_recipient_count is not None:
+            if restricted_recipient_count > 1:
+                msg = _(
+                    "Some recipients only accept direct messages that include "
+                    "someone who can authorize them."
+                )
+            else:
+                msg = _("This user only accepts direct messages from those who can authorize them.")
+        elif is_nobody_group:
             msg = _("Direct messages are disabled in this organization.")
         else:
             msg = _("This conversation does not include any users who can authorize it.")

--- a/zerver/migrations/miatsuco_0003_add_direct_message_self_authorize_group.py
+++ b/zerver/migrations/miatsuco_0003_add_direct_message_self_authorize_group.py
@@ -1,0 +1,30 @@
+# Fork migration (miatsuco): add the direct_message_self_authorize_group realm setting.
+#
+# Added as a nullable ForeignKey first; miatsuco_0004 sets the default group
+# for existing realms and miatsuco_0005 makes it non-null, mirroring how
+# upstream added direct_message_initiator_group / direct_message_permission_group
+# (migrations 0549, 0550, 0551). A group-permission setting cannot use a static
+# default, which is why it takes three steps.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "miatsuco_0002_add_web_show_upload_thumbnails"),
+        ("zerver", "0804_backfill_user_created_audit_logs"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="realm",
+            name="direct_message_self_authorize_group",
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.RESTRICT,
+                related_name="+",
+                to="zerver.usergroup",
+            ),
+        ),
+    ]

--- a/zerver/migrations/miatsuco_0004_set_default_direct_message_self_authorize_group.py
+++ b/zerver/migrations/miatsuco_0004_set_default_direct_message_self_authorize_group.py
@@ -1,0 +1,43 @@
+# Fork migration (miatsuco): set the default value of direct_message_self_authorize_group
+# for existing realms to the NOBODY system group. This preserves the prior
+# behavior: with an empty self-authorize group, a direct message is authorized only when
+# a direct_message_permission_group member is present, exactly as before this
+# feature existed. An admin opts in by widening the self-authorize group.
+
+from django.db import migrations
+from django.db.backends.base.schema import BaseDatabaseSchemaEditor
+from django.db.migrations.state import StateApps
+from django.db.models import OuterRef
+
+
+def set_default_value_for_direct_message_self_authorize_group(
+    apps: StateApps, schema_editor: BaseDatabaseSchemaEditor
+) -> None:
+    Realm = apps.get_model("zerver", "Realm")
+    NamedUserGroup = apps.get_model("zerver", "NamedUserGroup")
+
+    NOBODY_GROUP_NAME = "role:nobody"
+
+    Realm.objects.filter(
+        direct_message_self_authorize_group=None,
+    ).update(
+        direct_message_self_authorize_group=NamedUserGroup.objects.filter(
+            name=NOBODY_GROUP_NAME, realm=OuterRef("id"), is_system_group=True
+        ).values("pk")
+    )
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("zerver", "miatsuco_0003_add_direct_message_self_authorize_group"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            set_default_value_for_direct_message_self_authorize_group,
+            elidable=True,
+            reverse_code=migrations.RunPython.noop,
+        ),
+    ]

--- a/zerver/migrations/miatsuco_0005_alter_direct_message_self_authorize_group_non_null.py
+++ b/zerver/migrations/miatsuco_0005_alter_direct_message_self_authorize_group_non_null.py
@@ -1,0 +1,24 @@
+# Fork migration (miatsuco): now that every realm has a direct_message_self_authorize_group
+# (set by miatsuco_0004), make the ForeignKey non-null, matching the two
+# existing DM group settings.
+
+import django.db.models.deletion
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "miatsuco_0004_set_default_direct_message_self_authorize_group"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="realm",
+            name="direct_message_self_authorize_group",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.RESTRICT,
+                related_name="+",
+                to="zerver.usergroup",
+            ),
+        ),
+    ]

--- a/zerver/migrations/miatsuco_0006_add_restrict_dms_to_authorizers.py
+++ b/zerver/migrations/miatsuco_0006_add_restrict_dms_to_authorizers.py
@@ -1,0 +1,27 @@
+# Fork migration (miatsuco): add the personal miatsuco_restrict_dms_to_authorizers
+# setting. A boolean takes a static default, so unlike a group-setting field
+# this needs only a single migration (no add-nullable / backfill / non-null
+# sequence). The field lives on UserBaseSettings, so it is added to both
+# RealmUserDefault (the org-wide default) and UserProfile (the per-user value),
+# mirroring miatsuco_0002.
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("zerver", "miatsuco_0005_alter_direct_message_self_authorize_group_non_null"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="realmuserdefault",
+            name="miatsuco_restrict_dms_to_authorizers",
+            field=models.BooleanField(db_default=False, default=False),
+        ),
+        migrations.AddField(
+            model_name="userprofile",
+            name="miatsuco_restrict_dms_to_authorizers",
+            field=models.BooleanField(db_default=False, default=False),
+        ),
+    ]

--- a/zerver/models/realms.py
+++ b/zerver/models/realms.py
@@ -373,6 +373,16 @@ class Realm(models.Model):
         "UserGroup", on_delete=models.RESTRICT, related_name="+"
     )
 
+    # Fork feature (miatsuco): UserGroup whose members may exchange direct
+    # messages with each other without a member of
+    # direct_message_permission_group being present. A direct message with no
+    # permission-group member is allowed only if every participant (sender and
+    # all recipients) is in this "peer" group. Default NOBODY preserves the
+    # upstream behavior (only the permission group authorizes a DM).
+    direct_message_self_authorize_group = models.ForeignKey(
+        "UserGroup", on_delete=models.RESTRICT, related_name="+"
+    )
+
     # on_delete field here is set to RESTRICT because we don't want to allow
     # deleting a user group in case it is referenced by this setting.
     # We are not using PROTECT since we want to allow deletion of user groups
@@ -934,6 +944,11 @@ class Realm(models.Model):
             allow_nobody_group=True,
             allow_everyone_group=True,
             default_group_name=SystemGroups.EVERYONE,
+        ),
+        direct_message_self_authorize_group=GroupPermissionSetting(
+            allow_nobody_group=True,
+            allow_everyone_group=True,
+            default_group_name=SystemGroups.NOBODY,
         ),
         workplace_users_group=GroupPermissionSetting(
             allow_nobody_group=True,

--- a/zerver/models/users.py
+++ b/zerver/models/users.py
@@ -112,6 +112,15 @@ class UserBaseSettings(models.Model):
     # inline_upload_preview.
     miatsuco_web_show_upload_thumbnails = models.BooleanField(default=True, db_default=True)
 
+    # Fork feature (miatsuco): personal DM restriction. When enabled, this
+    # user can only be a participant in a direct message (1:1 or group) that
+    # includes a member of the realm's direct_message_permission_group (the
+    # users who can authorize a DM). This lets an individual opt out of the
+    # realm's direct_message_self_authorize_group allowance, which otherwise
+    # permits a configured set to exchange DMs with no authorizer present.
+    # Default False preserves prior behavior (no personal restriction).
+    miatsuco_restrict_dms_to_authorizers = models.BooleanField(default=False, db_default=False)
+
     # UI setting controlling Zulip's behavior of demoting in the sort
     # order and graying out streams with no recent traffic.  The
     # default behavior, automatic, enables this behavior once a user
@@ -405,6 +414,7 @@ class UserBaseSettings(models.Model):
         web_mark_read_on_scroll_policy=int,
         web_navigate_to_sent_message=bool,
         miatsuco_web_show_upload_thumbnails=bool,
+        miatsuco_restrict_dms_to_authorizers=bool,
         web_stream_unreads_count_display_policy=int,
         web_suggest_update_timezone=bool,
     )

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -15425,6 +15425,18 @@ paths:
                     **Changes**: New in Zulip 10.0 (feature level 329).
                   type: boolean
                   example: true
+                miatsuco_restrict_dms_to_authorizers:
+                  type: boolean
+                  description: |
+                    Whether this user opts out of direct messages that include any
+                    user who cannot authorize the conversation. When enabled, every
+                    other participant in a direct message with this user must be a
+                    member of the realm's `direct_message_permission_group`; a single
+                    non-authorizing participant blocks the conversation, even if an
+                    authorizer is also present. This is bidirectional (it also
+                    restricts direct messages this user sends) and overrides the
+                    realm's `direct_message_self_authorize_group` allowance for this
+                    user. Specific to the MiAtSu.Co fork.
                 miatsuco_web_show_upload_thumbnails:
                   type: boolean
                   description: |
@@ -15980,6 +15992,8 @@ paths:
               receives_typing_notifications:
                 contentType: application/json
               web_suggest_update_timezone:
+                contentType: application/json
+              miatsuco_restrict_dms_to_authorizers:
                 contentType: application/json
               miatsuco_web_show_upload_thumbnails:
                 contentType: application/json
@@ -19624,6 +19638,18 @@ paths:
                               time zone configured on their device.
 
                               **Changes**: New in Zulip 10.0 (feature level 329).
+                          miatsuco_restrict_dms_to_authorizers:
+                            type: boolean
+                            description: |
+                              Whether this user opts out of direct messages that include
+                              any user who cannot authorize the conversation. When enabled,
+                              every other participant in a direct message with this user must
+                              be a member of the realm's `direct_message_permission_group`; a
+                              single non-authorizing participant blocks the conversation, even
+                              if an authorizer is also present. This is bidirectional (it also
+                              restricts direct messages this user sends) and overrides the
+                              realm's `direct_message_self_authorize_group` allowance for this
+                              user. Specific to the MiAtSu.Co fork.
                           miatsuco_web_show_upload_thumbnails:
                             type: boolean
                             description: |
@@ -22065,6 +22091,18 @@ paths:
                               time zone configured on their device.
 
                               **Changes**: New in Zulip 10.0 (feature level 329).
+                          miatsuco_restrict_dms_to_authorizers:
+                            type: boolean
+                            description: |
+                              Whether this user opts out of direct messages that include
+                              any user who cannot authorize the conversation. When enabled,
+                              every other participant in a direct message with this user must
+                              be a member of the realm's `direct_message_permission_group`; a
+                              single non-authorizing participant blocks the conversation, even
+                              if an authorizer is also present. This is bidirectional (it also
+                              restricts direct messages this user sends) and overrides the
+                              realm's `direct_message_self_authorize_group` allowance for this
+                              user. Specific to the MiAtSu.Co fork.
                           miatsuco_web_show_upload_thumbnails:
                             type: boolean
                             description: |
@@ -23382,6 +23420,18 @@ paths:
 
                     **Changes**: New in Zulip 10.0 (feature level 329).
                   example: true
+                miatsuco_restrict_dms_to_authorizers:
+                  type: boolean
+                  description: |
+                    Whether this user opts out of direct messages that include any
+                    user who cannot authorize the conversation. When enabled, every
+                    other participant in a direct message with this user must be a
+                    member of the realm's `direct_message_permission_group`; a single
+                    non-authorizing participant blocks the conversation, even if an
+                    authorizer is also present. This is bidirectional (it also
+                    restricts direct messages this user sends) and overrides the
+                    realm's `direct_message_self_authorize_group` allowance for this
+                    user. Specific to the MiAtSu.Co fork.
                 miatsuco_web_show_upload_thumbnails:
                   type: boolean
                   description: |
@@ -24030,6 +24080,8 @@ paths:
               receives_typing_notifications:
                 contentType: application/json
               web_suggest_update_timezone:
+                contentType: application/json
+              miatsuco_restrict_dms_to_authorizers:
                 contentType: application/json
               miatsuco_web_show_upload_thumbnails:
                 contentType: application/json

--- a/zerver/openapi/zulip.yaml
+++ b/zerver/openapi/zulip.yaml
@@ -5513,15 +5513,31 @@ paths:
                                             A [group-setting value](/api/group-setting-values) defining the set of
                                             users who have permission to fully use direct messages. Users outside
                                             this group can only send direct messages to conversations where all the
-                                            recipients are in this group, are bots, or are the sender, ensuring that
-                                            every direct message conversation will be visible to at least one user in
-                                            this group.
+                                            recipients are in this group, are bots, or are the sender.
+
+                                            In upstream Zulip this ensures every direct message conversation is
+                                            visible to at least one user in this group. The fork-specific
+                                            `direct_message_self_authorize_group` setting relaxes this: a
+                                            conversation whose participants are all in that group is permitted
+                                            without any member of this group being present.
 
                                             **Changes**: New in Zulip 9.0 (feature level 270).
 
                                             Previously, access to send direct messages was controlled by the
                                             `private_message_policy` realm setting, which supported values of
                                             1 (enabled) and 2 (disabled).
+                                        - $ref: "#/components/schemas/GroupSettingValue"
+                                    direct_message_self_authorize_group:
+                                      allOf:
+                                        - description: |
+                                            A [group-setting value](/api/group-setting-values) defining a set of
+                                            users who may exchange direct messages with each other without a member
+                                            of `direct_message_permission_group` being present. A direct message
+                                            with no `direct_message_permission_group` member is permitted only if
+                                            every participant (sender and all recipients) is in this setting.
+
+                                            This is a fork-specific (MiAtSu.Co) setting and is not part of upstream
+                                            Zulip.
                                         - $ref: "#/components/schemas/GroupSettingValue"
                                     disallow_disposable_email_addresses:
                                       type: boolean
@@ -21060,15 +21076,33 @@ paths:
                               A [group-setting value](/api/group-setting-values) defining the set of
                               users who have permission to fully use direct messages. Users outside
                               this group can only send direct messages to conversations where all the
-                              recipients are in this group, are bots, or are the sender, ensuring that
-                              every direct message conversation will be visible to at least one user in
-                              this group.
+                              recipients are in this group, are bots, or are the sender.
+
+                              In upstream Zulip this ensures every direct message conversation is
+                              visible to at least one user in this group. The fork-specific
+                              `direct_message_self_authorize_group` setting relaxes this: a
+                              conversation whose participants are all in that group is permitted
+                              without any member of this group being present.
 
                               **Changes**: New in Zulip 9.0 (feature level 270).
 
                               Previously, access to send direct messages was controlled by the
                               `private_message_policy` realm setting, which supported values of
                               1 (enabled) and 2 (disabled).
+                          - $ref: "#/components/schemas/GroupSettingValue"
+                      realm_direct_message_self_authorize_group:
+                        allOf:
+                          - description: |
+                              Present if `realm` is present in `fetch_event_types`.
+
+                              A [group-setting value](/api/group-setting-values) defining a set of
+                              users who may exchange direct messages with each other without a member
+                              of `realm_direct_message_permission_group` being present. A direct
+                              message with no permission-group member is permitted only if every
+                              participant (sender and all recipients) is in this setting.
+
+                              This is a fork-specific (MiAtSu.Co) setting and is not part of upstream
+                              Zulip.
                           - $ref: "#/components/schemas/GroupSettingValue"
                       realm_default_code_block_language:
                         type: string

--- a/zerver/tests/test_home.py
+++ b/zerver/tests/test_home.py
@@ -176,6 +176,7 @@ class HomeTest(ZulipTestCase):
         "realm_digest_emails_enabled",
         "realm_digest_weekday",
         "realm_direct_message_initiator_group",
+        "realm_direct_message_self_authorize_group",
         "realm_direct_message_permission_group",
         "realm_disallow_disposable_email_addresses",
         "realm_domains",

--- a/zerver/tests/test_miatsuco_dm_restrict.py
+++ b/zerver/tests/test_miatsuco_dm_restrict.py
@@ -50,8 +50,14 @@ class MiatsucoRestrictDMsToAuthorizersTest(ZulipTestCase):
         # Baseline: group1 <-> group1 is allowed via the self-authorize path.
         self.send_personal_message(g1_a, g1_b)
 
-        # g1_b opts into the personal restriction.
-        do_change_user_setting(g1_b, "miatsuco_restrict_dms_to_authorizers", True, acting_user=None)
+        # g1_b opts into the personal restriction. Wrap the change in
+        # captureOnCommitCallbacks so the on_commit user-cache flush runs; the
+        # test transaction never commits, and without this a later send would
+        # read a stale cached UserProfile and miss the opt-in.
+        with self.captureOnCommitCallbacks(execute=True):
+            do_change_user_setting(
+                g1_b, "miatsuco_restrict_dms_to_authorizers", True, acting_user=None
+            )
         g1_b.refresh_from_db()
 
         # A self-authorized DM from non-authorizer g1_a to g1_b is now blocked:
@@ -91,7 +97,10 @@ class MiatsucoRestrictDMsToAuthorizersTest(ZulipTestCase):
 
         # With more than one opted-in recipient, the general message is used so
         # that no single recipient is identified.
-        do_change_user_setting(g1_a, "miatsuco_restrict_dms_to_authorizers", True, acting_user=None)
+        with self.captureOnCommitCallbacks(execute=True):
+            do_change_user_setting(
+                g1_a, "miatsuco_restrict_dms_to_authorizers", True, acting_user=None
+            )
         g1_a.refresh_from_db()
         with self.assertRaises(DirectMessagePermissionError) as blocked_group:
             self.send_group_direct_message(moderator, [moderator, g1_a, g1_b])
@@ -100,17 +109,19 @@ class MiatsucoRestrictDMsToAuthorizersTest(ZulipTestCase):
             "Some recipients only accept direct messages that include "
             "someone who can authorize them.",
         )
-        do_change_user_setting(
-            g1_a, "miatsuco_restrict_dms_to_authorizers", False, acting_user=None
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            do_change_user_setting(
+                g1_a, "miatsuco_restrict_dms_to_authorizers", False, acting_user=None
+            )
         g1_a.refresh_from_db()
 
         # Self-DMs are always allowed regardless of the setting.
         self.send_personal_message(g1_b, g1_b)
 
         # Turning the setting back off restores the self-authorize allowance.
-        do_change_user_setting(
-            g1_b, "miatsuco_restrict_dms_to_authorizers", False, acting_user=None
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            do_change_user_setting(
+                g1_b, "miatsuco_restrict_dms_to_authorizers", False, acting_user=None
+            )
         g1_b.refresh_from_db()
         self.send_personal_message(g1_a, g1_b)

--- a/zerver/tests/test_miatsuco_dm_restrict.py
+++ b/zerver/tests/test_miatsuco_dm_restrict.py
@@ -1,0 +1,114 @@
+from zerver.actions.realm_settings import do_change_realm_permission_group_setting
+from zerver.actions.user_groups import check_add_user_group
+from zerver.actions.user_settings import do_change_user_setting
+from zerver.actions.users import do_change_user_role
+from zerver.lib.exceptions import DirectMessagePermissionError
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.models import NamedUserGroup, UserProfile
+from zerver.models.groups import SystemGroups
+from zerver.models.realms import get_realm
+
+
+class MiatsucoRestrictDMsToAuthorizersTest(ZulipTestCase):
+    """
+    Fork feature (miatsuco): the personal miatsuco_restrict_dms_to_authorizers
+    setting makes a user opt out of any direct message that includes a
+    non-authorizer. For an opted-in user, every other human participant must be
+    a member of direct_message_permission_group. This is bidirectional (it
+    governs the opted-in user's outgoing DMs too) and overrides the realm
+    direct_message_self_authorize_group allowance for that user.
+    """
+
+    def test_restrict_dms_to_authorizers(self) -> None:
+        realm = get_realm("zulip")
+
+        g1_a = self.example_user("hamlet")
+        g1_b = self.example_user("cordelia")
+        moderator = self.example_user("shiva")
+        another_moderator = self.example_user("iago")
+        do_change_user_role(moderator, UserProfile.ROLE_MODERATOR, acting_user=None)
+        do_change_user_role(another_moderator, UserProfile.ROLE_MODERATOR, acting_user=None)
+
+        moderators_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MODERATORS, realm_for_sharding=realm, is_system_group=True
+        )
+        group1 = check_add_user_group(realm, "group1", [g1_a, g1_b], acting_user=g1_a)
+
+        # Authorizers are moderators-and-above; group1 may self-authorize DMs
+        # among themselves without an authorizer present.
+        do_change_realm_permission_group_setting(
+            realm, "direct_message_permission_group", moderators_group, acting_user=None
+        )
+        do_change_realm_permission_group_setting(
+            realm, "direct_message_self_authorize_group", group1, acting_user=None
+        )
+        for user in (g1_a, g1_b, moderator, another_moderator):
+            user.refresh_from_db()
+
+        # Baseline: group1 <-> group1 is allowed via the self-authorize path.
+        self.send_personal_message(g1_a, g1_b)
+
+        # g1_b opts into the personal restriction.
+        do_change_user_setting(g1_b, "miatsuco_restrict_dms_to_authorizers", True, acting_user=None)
+        g1_b.refresh_from_db()
+
+        # A self-authorized DM from non-authorizer g1_a to g1_b is now blocked:
+        # g1_a is not an authorizer. A single opted-in recipient gets the
+        # specific "this user" message.
+        with self.assertRaises(DirectMessagePermissionError) as blocked_1to1:
+            self.send_personal_message(g1_a, g1_b)
+        self.assertEqual(
+            str(blocked_1to1.exception),
+            "This user only accepts direct messages from those who can authorize them.",
+        )
+
+        # The restriction is bidirectional: g1_b also cannot start a DM with a
+        # non-authorizer. When only the sender has opted in there is no opted-in
+        # recipient to name, so the general "some recipients" message is used.
+        with self.assertRaises(DirectMessagePermissionError) as blocked_as_sender:
+            self.send_personal_message(g1_b, g1_a)
+        self.assertEqual(
+            str(blocked_as_sender.exception),
+            "Some recipients only accept direct messages that include "
+            "someone who can authorize them.",
+        )
+
+        # A group DM in which any participant is a non-authorizer is blocked,
+        # EVEN IF an authorizer is also present: including a moderator does not
+        # let a non-authorizer (g1_a) share a DM with the opted-in g1_b.
+        with self.assertRaises(DirectMessagePermissionError):
+            self.send_group_direct_message(g1_a, [g1_a, g1_b, moderator])
+
+        # A 1:1 DM with an authorizer is allowed: the only other participant is
+        # a moderator.
+        self.send_personal_message(moderator, g1_b)
+
+        # A group DM is allowed only when every other participant authorizes:
+        # g1_b with two moderators and no non-authorizer.
+        self.send_group_direct_message(moderator, [moderator, another_moderator, g1_b])
+
+        # With more than one opted-in recipient, the general message is used so
+        # that no single recipient is identified.
+        do_change_user_setting(g1_a, "miatsuco_restrict_dms_to_authorizers", True, acting_user=None)
+        g1_a.refresh_from_db()
+        with self.assertRaises(DirectMessagePermissionError) as blocked_group:
+            self.send_group_direct_message(moderator, [moderator, g1_a, g1_b])
+        self.assertEqual(
+            str(blocked_group.exception),
+            "Some recipients only accept direct messages that include "
+            "someone who can authorize them.",
+        )
+        do_change_user_setting(
+            g1_a, "miatsuco_restrict_dms_to_authorizers", False, acting_user=None
+        )
+        g1_a.refresh_from_db()
+
+        # Self-DMs are always allowed regardless of the setting.
+        self.send_personal_message(g1_b, g1_b)
+
+        # Turning the setting back off restores the self-authorize allowance.
+        do_change_user_setting(
+            g1_b, "miatsuco_restrict_dms_to_authorizers", False, acting_user=None
+        )
+        g1_b.refresh_from_db()
+        self.send_personal_message(g1_a, g1_b)

--- a/zerver/tests/test_miatsuco_dm_restrict.py
+++ b/zerver/tests/test_miatsuco_dm_restrict.py
@@ -125,3 +125,29 @@ class MiatsucoRestrictDMsToAuthorizersTest(ZulipTestCase):
             )
         g1_b.refresh_from_db()
         self.send_personal_message(g1_a, g1_b)
+
+        # When direct_message_permission_group is a named (non-system) group,
+        # authorizer membership is resolved by group membership rather than by
+        # role. Point the permission group at a named group and re-enable the
+        # restriction to exercise that path.
+        othello = self.example_user("othello")
+        named_authorizers = check_add_user_group(
+            realm, "named_authorizers", [othello], acting_user=g1_a
+        )
+        with self.captureOnCommitCallbacks(execute=True):
+            do_change_realm_permission_group_setting(
+                realm, "direct_message_permission_group", named_authorizers, acting_user=None
+            )
+            do_change_user_setting(
+                g1_b, "miatsuco_restrict_dms_to_authorizers", True, acting_user=None
+            )
+        for user in (g1_a, g1_b, othello):
+            user.refresh_from_db()
+
+        # othello is a member of the named authorizer group, so a DM to the
+        # opted-in g1_b is allowed.
+        self.send_personal_message(othello, g1_b)
+
+        # g1_a is not in the named authorizer group, so a DM to g1_b is blocked.
+        with self.assertRaises(DirectMessagePermissionError):
+            self.send_personal_message(g1_a, g1_b)

--- a/zerver/tests/test_miatsuco_dm_restrict.py
+++ b/zerver/tests/test_miatsuco_dm_restrict.py
@@ -26,8 +26,10 @@ class MiatsucoRestrictDMsToAuthorizersTest(ZulipTestCase):
         g1_b = self.example_user("cordelia")
         moderator = self.example_user("shiva")
         another_moderator = self.example_user("iago")
-        do_change_user_role(moderator, UserProfile.ROLE_MODERATOR, acting_user=None)
-        do_change_user_role(another_moderator, UserProfile.ROLE_MODERATOR, acting_user=None)
+        do_change_user_role(moderator, UserProfile.ROLE_MODERATOR, acting_user=None, notify=False)
+        do_change_user_role(
+            another_moderator, UserProfile.ROLE_MODERATOR, acting_user=None, notify=False
+        )
 
         moderators_group = NamedUserGroup.objects.get(
             name=SystemGroups.MODERATORS, realm_for_sharding=realm, is_system_group=True

--- a/zerver/tests/test_miatsuco_dm_self_authorize.py
+++ b/zerver/tests/test_miatsuco_dm_self_authorize.py
@@ -42,20 +42,16 @@ class MiatsucoDMSelfAuthorizeTest(ZulipTestCase):
         )
         group1 = check_add_user_group(realm, "group1", [g1_a, g1_b], acting_user=g1_a)
 
-        # Configure the stated scenario. Wrap realm setting changes in
-        # captureOnCommitCallbacks so their on_commit cache flushes run; the
-        # test transaction never commits, and without this a later send reads a
-        # stale cached realm (via sender.realm) and enforces the old setting.
-        with self.captureOnCommitCallbacks(execute=True):
-            do_change_realm_permission_group_setting(
-                realm, "direct_message_permission_group", moderators_group, acting_user=None
-            )
-            do_change_realm_permission_group_setting(
-                realm, "direct_message_initiator_group", members_group, acting_user=None
-            )
-            do_change_realm_permission_group_setting(
-                realm, "direct_message_self_authorize_group", group1, acting_user=None
-            )
+        # Configure the stated scenario.
+        do_change_realm_permission_group_setting(
+            realm, "direct_message_permission_group", moderators_group, acting_user=None
+        )
+        do_change_realm_permission_group_setting(
+            realm, "direct_message_initiator_group", members_group, acting_user=None
+        )
+        do_change_realm_permission_group_setting(
+            realm, "direct_message_self_authorize_group", group1, acting_user=None
+        )
         for user in (g1_a, g1_b, member, guest, moderator):
             user.refresh_from_db()
 
@@ -93,13 +89,12 @@ class MiatsucoDMSelfAuthorizeTest(ZulipTestCase):
             [member],
             [group1],
         )
-        with self.captureOnCommitCallbacks(execute=True):
-            do_change_realm_permission_group_setting(
-                realm,
-                "direct_message_self_authorize_group",
-                anonymous_self_authorize_group,
-                acting_user=None,
-            )
+        do_change_realm_permission_group_setting(
+            realm,
+            "direct_message_self_authorize_group",
+            anonymous_self_authorize_group,
+            acting_user=None,
+        )
         member.refresh_from_db()
         # Now member is a peer too, so group1 <-> member is authorized unmodded.
         self.send_personal_message(g1_a, member)
@@ -112,10 +107,9 @@ class MiatsucoDMSelfAuthorizeTest(ZulipTestCase):
         nobody_group = NamedUserGroup.objects.get(
             name=SystemGroups.NOBODY, realm_for_sharding=realm, is_system_group=True
         )
-        with self.captureOnCommitCallbacks(execute=True):
-            do_change_realm_permission_group_setting(
-                realm, "direct_message_self_authorize_group", nobody_group, acting_user=None
-            )
+        do_change_realm_permission_group_setting(
+            realm, "direct_message_self_authorize_group", nobody_group, acting_user=None
+        )
         for user in (g1_a, g1_b):
             user.refresh_from_db()
         with self.assertRaises(DirectMessagePermissionError):

--- a/zerver/tests/test_miatsuco_dm_self_authorize.py
+++ b/zerver/tests/test_miatsuco_dm_self_authorize.py
@@ -95,7 +95,11 @@ class MiatsucoDMSelfAuthorizeTest(ZulipTestCase):
             anonymous_self_authorize_group,
             acting_user=None,
         )
-        member.refresh_from_db()
+        # Refresh every participant, including the sender: check_message reads
+        # the realm via sender.realm, so a stale cached relation on the sender
+        # would enforce the previous self-authorize group.
+        for user in (g1_a, member, guest):
+            user.refresh_from_db()
         # Now member is a peer too, so group1 <-> member is authorized unmodded.
         self.send_personal_message(g1_a, member)
         # Guest is still not a peer, so still needs a mod.

--- a/zerver/tests/test_miatsuco_dm_self_authorize.py
+++ b/zerver/tests/test_miatsuco_dm_self_authorize.py
@@ -31,8 +31,8 @@ class MiatsucoDMSelfAuthorizeTest(ZulipTestCase):
         guest = self.example_user("polonius")
         moderator = self.example_user("shiva")
 
-        do_change_user_role(guest, UserProfile.ROLE_GUEST, acting_user=None)
-        do_change_user_role(moderator, UserProfile.ROLE_MODERATOR, acting_user=None)
+        do_change_user_role(guest, UserProfile.ROLE_GUEST, acting_user=None, notify=False)
+        do_change_user_role(moderator, UserProfile.ROLE_MODERATOR, acting_user=None, notify=False)
 
         moderators_group = NamedUserGroup.objects.get(
             name=SystemGroups.MODERATORS, realm_for_sharding=realm, is_system_group=True

--- a/zerver/tests/test_miatsuco_dm_self_authorize.py
+++ b/zerver/tests/test_miatsuco_dm_self_authorize.py
@@ -42,16 +42,20 @@ class MiatsucoDMSelfAuthorizeTest(ZulipTestCase):
         )
         group1 = check_add_user_group(realm, "group1", [g1_a, g1_b], acting_user=g1_a)
 
-        # Configure the stated scenario.
-        do_change_realm_permission_group_setting(
-            realm, "direct_message_permission_group", moderators_group, acting_user=None
-        )
-        do_change_realm_permission_group_setting(
-            realm, "direct_message_initiator_group", members_group, acting_user=None
-        )
-        do_change_realm_permission_group_setting(
-            realm, "direct_message_self_authorize_group", group1, acting_user=None
-        )
+        # Configure the stated scenario. Wrap realm setting changes in
+        # captureOnCommitCallbacks so their on_commit cache flushes run; the
+        # test transaction never commits, and without this a later send reads a
+        # stale cached realm (via sender.realm) and enforces the old setting.
+        with self.captureOnCommitCallbacks(execute=True):
+            do_change_realm_permission_group_setting(
+                realm, "direct_message_permission_group", moderators_group, acting_user=None
+            )
+            do_change_realm_permission_group_setting(
+                realm, "direct_message_initiator_group", members_group, acting_user=None
+            )
+            do_change_realm_permission_group_setting(
+                realm, "direct_message_self_authorize_group", group1, acting_user=None
+            )
         for user in (g1_a, g1_b, member, guest, moderator):
             user.refresh_from_db()
 
@@ -89,12 +93,13 @@ class MiatsucoDMSelfAuthorizeTest(ZulipTestCase):
             [member],
             [group1],
         )
-        do_change_realm_permission_group_setting(
-            realm,
-            "direct_message_self_authorize_group",
-            anonymous_self_authorize_group,
-            acting_user=None,
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            do_change_realm_permission_group_setting(
+                realm,
+                "direct_message_self_authorize_group",
+                anonymous_self_authorize_group,
+                acting_user=None,
+            )
         member.refresh_from_db()
         # Now member is a peer too, so group1 <-> member is authorized unmodded.
         self.send_personal_message(g1_a, member)
@@ -107,9 +112,10 @@ class MiatsucoDMSelfAuthorizeTest(ZulipTestCase):
         nobody_group = NamedUserGroup.objects.get(
             name=SystemGroups.NOBODY, realm_for_sharding=realm, is_system_group=True
         )
-        do_change_realm_permission_group_setting(
-            realm, "direct_message_self_authorize_group", nobody_group, acting_user=None
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            do_change_realm_permission_group_setting(
+                realm, "direct_message_self_authorize_group", nobody_group, acting_user=None
+            )
         for user in (g1_a, g1_b):
             user.refresh_from_db()
         with self.assertRaises(DirectMessagePermissionError):

--- a/zerver/tests/test_miatsuco_dm_self_authorize.py
+++ b/zerver/tests/test_miatsuco_dm_self_authorize.py
@@ -1,0 +1,116 @@
+from zerver.actions.realm_settings import do_change_realm_permission_group_setting
+from zerver.actions.user_groups import check_add_user_group
+from zerver.actions.users import do_change_user_role
+from zerver.lib.exceptions import DirectMessagePermissionError
+from zerver.lib.test_classes import ZulipTestCase
+from zerver.models import NamedUserGroup, UserProfile
+from zerver.models.groups import SystemGroups
+from zerver.models.realms import get_realm
+
+
+class MiatsucoDMSelfAuthorizeTest(ZulipTestCase):
+    """
+    Fork feature (miatsuco): direct_message_self_authorize_group lets a
+    configured set exchange DMs among themselves without a permission-group
+    member, while any participant outside that set still requires one.
+    """
+
+    def test_direct_message_self_authorize_group_setting(self) -> None:
+        """
+        This test encodes the authorization matrix from the design note under
+        the stated scenario: permission group = Moderators, initiator =
+        Members, peer = group 1.
+        """
+        realm = get_realm("zulip")
+
+        # group 1 members.
+        g1_a = self.example_user("hamlet")
+        g1_b = self.example_user("cordelia")
+        # not in group 1: an ordinary member, a guest, and a moderator.
+        member = self.example_user("othello")
+        guest = self.example_user("polonius")
+        moderator = self.example_user("shiva")
+
+        do_change_user_role(guest, UserProfile.ROLE_GUEST, acting_user=None)
+        do_change_user_role(moderator, UserProfile.ROLE_MODERATOR, acting_user=None)
+
+        moderators_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MODERATORS, realm_for_sharding=realm, is_system_group=True
+        )
+        members_group = NamedUserGroup.objects.get(
+            name=SystemGroups.MEMBERS, realm_for_sharding=realm, is_system_group=True
+        )
+        group1 = check_add_user_group(realm, "group1", [g1_a, g1_b], acting_user=g1_a)
+
+        # Configure the stated scenario.
+        do_change_realm_permission_group_setting(
+            realm, "direct_message_permission_group", moderators_group, acting_user=None
+        )
+        do_change_realm_permission_group_setting(
+            realm, "direct_message_initiator_group", members_group, acting_user=None
+        )
+        do_change_realm_permission_group_setting(
+            realm, "direct_message_self_authorize_group", group1, acting_user=None
+        )
+        for user in (g1_a, g1_b, member, guest, moderator):
+            user.refresh_from_db()
+
+        # group1 -> group1: authorized by the peer path, no mod needed.
+        self.send_personal_message(g1_a, g1_b)
+
+        # group1 -> member: member is not a peer and no mod is present.
+        with self.assertRaises(DirectMessagePermissionError):
+            self.send_personal_message(g1_a, member)
+
+        # group1 -> guest: guest is not a peer and no mod is present.
+        with self.assertRaises(DirectMessagePermissionError):
+            self.send_personal_message(g1_a, guest)
+
+        # member -> member: neither is a peer and no mod is present.
+        with self.assertRaises(DirectMessagePermissionError):
+            self.send_personal_message(member, g1_a)
+
+        # Any DM including a moderator is authorized (escape hatch), for every
+        # sender class, including a guest recipient and a cross-group group DM.
+        self.send_personal_message(g1_a, moderator)
+        self.send_personal_message(member, moderator)
+        self.send_group_direct_message(member, [member, moderator, guest])
+        self.send_group_direct_message(g1_a, [g1_a, member, moderator])
+
+        # group1 group DM stays authorized as long as every participant is a peer.
+        self.send_group_direct_message(g1_a, [g1_a, g1_b])
+        # But one non-peer participant breaks the peer path (no mod present).
+        with self.assertRaises(DirectMessagePermissionError):
+            self.send_group_direct_message(g1_a, [g1_a, g1_b, member])
+
+        # The peer path also works when the peer setting is an anonymous group
+        # combining a group and an individual user.
+        anonymous_self_authorize_group = self.create_or_update_anonymous_group_for_setting(
+            [member],
+            [group1],
+        )
+        do_change_realm_permission_group_setting(
+            realm,
+            "direct_message_self_authorize_group",
+            anonymous_self_authorize_group,
+            acting_user=None,
+        )
+        member.refresh_from_db()
+        # Now member is a peer too, so group1 <-> member is authorized unmodded.
+        self.send_personal_message(g1_a, member)
+        # Guest is still not a peer, so still needs a mod.
+        with self.assertRaises(DirectMessagePermissionError):
+            self.send_personal_message(g1_a, guest)
+
+        # With the peer group empty (NOBODY), behavior falls back to the
+        # permission-group rule alone: group1 -> group1 now needs a mod.
+        nobody_group = NamedUserGroup.objects.get(
+            name=SystemGroups.NOBODY, realm_for_sharding=realm, is_system_group=True
+        )
+        do_change_realm_permission_group_setting(
+            realm, "direct_message_self_authorize_group", nobody_group, acting_user=None
+        )
+        for user in (g1_a, g1_b):
+            user.refresh_from_db()
+        with self.assertRaises(DirectMessagePermissionError):
+            self.send_personal_message(g1_a, g1_b)

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -816,6 +816,7 @@ def update_realm_user_settings_defaults(
     | None = None,
     web_navigate_to_sent_message: Json[bool] | None = None,
     miatsuco_web_show_upload_thumbnails: Json[bool] | None = None,
+    miatsuco_restrict_dms_to_authorizers: Json[bool] | None = None,
     web_stream_unreads_count_display_policy: Json[
         Annotated[
             int,

--- a/zerver/views/realm.py
+++ b/zerver/views/realm.py
@@ -144,6 +144,7 @@ def update_realm(
     digest_weekday: Json[DigestWeekdayEnum] | None = None,
     direct_message_initiator_group: Json[GroupSettingChangeRequest] | None = None,
     direct_message_permission_group: Json[GroupSettingChangeRequest] | None = None,
+    direct_message_self_authorize_group: Json[GroupSettingChangeRequest] | None = None,
     disallow_disposable_email_addresses: Json[bool] | None = None,
     email_changes_disabled: Json[bool] | None = None,
     emails_restricted_to_domains: Json[bool] | None = None,

--- a/zerver/views/user_settings.py
+++ b/zerver/views/user_settings.py
@@ -373,6 +373,7 @@ def json_change_settings(
     | None = None,
     web_navigate_to_sent_message: Json[bool] | None = None,
     miatsuco_web_show_upload_thumbnails: Json[bool] | None = None,
+    miatsuco_restrict_dms_to_authorizers: Json[bool] | None = None,
     web_stream_unreads_count_display_policy: Annotated[
         Json[int],
         check_int_in_validator(UserProfile.WEB_STREAM_UNREADS_COUNT_DISPLAY_POLICY_CHOICES),


### PR DESCRIPTION
Adds two related direct-message permission features. Also fixes a responsive-view oversight on the inline video player, and implements an unfinished todo from upstream to surface DM error messages.

The first new feature adds a realm-level setting, `direct_message_self_authorize_group`, that lets a configured group exchange direct messages among themselves without a member of `direct_message_permission_group` (an authorizer) present. This is an expansion of the existing authorization feature and makes it so that DMs now check to make sure that either every member participating can do so without authorization, or that there is an authorizing member present.

The second adds a personal setting, `miatsuco_restrict_dms_to_authorizers`, that lets an individual opt out of any direct message that includes a non-authorizer. When enabled, every other participant in the conversation must be an authorizer, a single non-authorizer blocks it even if an authorizer is also present, and the restriction is bidirectional (it governs the opted-in user's outgoing DMs as well). The personal setting includes a read-only display of the current authorizers beneath the toggle, and a distinct error message so a blocked sender understands why delivery failed.

The HTML5 inline video player may still have some other issues to fix, but the controls now properly get contained in the embed.

Fixes: HTML5 inline player controls being clipped outside of the player wrapper in small viewports. Also implements missing DM error message hook.

**How changes were tested:** Backend enforcement is covered by two new fork test modules, `zerver/tests/test_miatsuco_dm_self_authorize.py` and `zerver/tests/test_miatsuco_dm_restrict.py`. Client-side, the self-authorize branch of `people.user_can_direct_message` and the authorizer-pill display module are covered by node tests. UI was verified manually in the browser (see screenshots).

**Screenshots and screen captures:**
Added a new realm setting that allows you to define groups that explicitly don't require authorization for DMs:
<img width="1207" height="990" alt="firefox_BNCXRkfsPd" src="https://github.com/user-attachments/assets/3a974025-18fc-48af-a13c-5ab6d79cc8c3" />
Added a new personal setting that allows users to restrict who can DM them to only those that are in the authorization role:
<img width="1203" height="984" alt="firefox_cWBA6bVO6N" src="https://github.com/user-attachments/assets/c885a8db-20cb-41e6-95ff-7d5c1528d771" />
DMs now properly surface errors when undelivered:
<img width="1571" height="966" alt="firefox_a6POvUw9rx" src="https://github.com/user-attachments/assets/553912a2-82f0-43b5-8d7a-c0946c929f95" />
HTML5 player with controls visible:
<img width="355" height="754" alt="firefox_gbWuYxeSYD" src="https://github.com/user-attachments/assets/570eb1d1-e615-4947-b30f-9ff412a95c2d" />

<details>
<summary>Self-review checklist</summary>

<!-- Prior to submitting a PR, follow our step-by-step guide to review your own code:
https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code -->

<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or not completed, leave them unchecked.-->

- [x] [Self-reviewed](https://zulip.readthedocs.io/en/latest/contributing/code-reviewing.html#how-to-review-code) the changes for clarity and maintainability
      (variable names, code reuse, readability, etc.).
- [x] Followed the [AI use policy](https://zulip.readthedocs.io/en/latest/contributing/contributing.html#ai-use-policy-and-guidelines).

Communicate decisions, questions, and potential concerns.

- [ ] Explains differences from previous plans (e.g., issue description).
- [x] Highlights technical choices and bugs encountered.
- [ ] Calls out remaining decisions and concerns.
- [x] Automated tests verify logic where appropriate.

Individual commits are ready for review (see [commit discipline](https://zulip.readthedocs.io/en/latest/contributing/commit-discipline.html)).

- [x] Each commit is a coherent idea.
- [ ] Commit message(s) explain reasoning and motivation for changes.

Completed manual review and testing of the following:

- [x] Visual appearance of the changes.
- [x] Responsiveness and internationalization.
- [x] Strings and tooltips.
- [x] End-to-end functionality of buttons, interactions and flows.
- [x] Corner cases, error conditions, and easily imagined bugs.
</details>
